### PR TITLE
fix(path): ensure path to css-base.js is JSON.stringified

### DIFF
--- a/packages/one-app-bundler/webpack/loaders/ssr-css-loader/index-style-loader.js
+++ b/packages/one-app-bundler/webpack/loaders/ssr-css-loader/index-style-loader.js
@@ -14,11 +14,13 @@
 
 const path = require('path');
 
-const cssBasePath = path.resolve(__dirname, 'css-base.js');
+// stringify handles win32 path slashes too
+// so `C:\path\node_modules` doesn't turn into something with a newline
+const cssBasePath = JSON.stringify(path.resolve(__dirname, 'css-base.js'));
 
 module.exports = function indexStyleLoader(content) {
   return `
   ${content}
-  __webpack_exports__.default.ssrStyles = require("${cssBasePath}")();
+  __webpack_exports__.default.ssrStyles = require(${cssBasePath})();
   `;
 };


### PR DESCRIPTION
This ensures that win32 slashes are handled.

Fixes #10

Steps to verify:

1. Cloned repo locally on a Windows machine (checked out this branch)
2. Ran `npm install` 
3. `cd` install `one-app-bundler`
4. Ran `npm pack`
5. npm installed the tgz file
6. Ran `npm build`

Below you can see the result
![powershell_snippet](https://user-images.githubusercontent.com/21000200/71385148-cfd51780-25a2-11ea-9c7e-4843783e67d2.PNG)
