### PR TITLE
update one-app-cli to v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [6.1.0](https://github.com/americanexpress/one-app-cli/compare/v6.0.0...v6.1.0) (2020-01-23)
+
+
+### Bug Fixes
+
+* **path:** ensure path to css-base.js is JSON.stringified ([#11](https://github.com/americanexpress/one-app-cli/issues/11)) ([3d4ff6b](https://github.com/americanexpress/one-app-cli/commit/3d4ff6babd3a0f42eb7235140630608e5028c1af)), closes [#10](https://github.com/americanexpress/one-app-cli/issues/10)
+
+
+### Features
+
+* **generator:** add generator-one-app-module ([#13](https://github.com/americanexpress/one-app-cli/issues/13)) ([0fd994b](https://github.com/americanexpress/one-app-cli/commit/0fd994b57d2fd9487b31f109f95d13c7e64c14aa))
+* **lerna:** upgrade lerna to v3.19.0 ([#9](https://github.com/americanexpress/one-app-cli/issues/9)) ([6dacd0b](https://github.com/americanexpress/one-app-cli/commit/6dacd0b8848d1f1045aff36fde2f0d441d0d49a2))
+* **one-app-bundler:** add chunk meta to one app build.meta file ([#14](https://github.com/americanexpress/one-app-cli/issues/14)) ([b8a9c3b](https://github.com/americanexpress/one-app-cli/commit/b8a9c3b740a00038d19f15fbbcf354d48a4d238c))

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "6.0.0"
+  "version": "6.1.0"
 }

--- a/packages/eslint-plugin-one-app/CHANGELOG.md
+++ b/packages/eslint-plugin-one-app/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [6.1.0](https://github.com/americanexpress/one-app-cli/compare/v6.0.0...v6.1.0) (2020-01-23)
+
+
+### Features
+
+* **generator:** add generator-one-app-module ([#13](https://github.com/americanexpress/one-app-cli/issues/13)) ([0fd994b](https://github.com/americanexpress/one-app-cli/commit/0fd994b57d2fd9487b31f109f95d13c7e64c14aa))
+* **lerna:** upgrade lerna to v3.19.0 ([#9](https://github.com/americanexpress/one-app-cli/issues/9)) ([6dacd0b](https://github.com/americanexpress/one-app-cli/commit/6dacd0b8848d1f1045aff36fde2f0d441d0d49a2))

--- a/packages/eslint-plugin-one-app/package-lock.json
+++ b/packages/eslint-plugin-one-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@americanexpress/eslint-plugin-one-app",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/eslint-plugin-one-app/package.json
+++ b/packages/eslint-plugin-one-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/eslint-plugin-one-app",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "This package has Eslint configurations used by one-app.",
   "main": "index.js",
   "jest": {

--- a/packages/generator-one-app-module/CHANGELOG.md
+++ b/packages/generator-one-app-module/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [6.1.0](https://github.com/americanexpress/one-app-cli/compare/v6.0.0...v6.1.0) (2020-01-23)
+
+
+### Features
+
+* **generator:** add generator-one-app-module ([#13](https://github.com/americanexpress/one-app-cli/issues/13)) ([0fd994b](https://github.com/americanexpress/one-app-cli/commit/0fd994b57d2fd9487b31f109f95d13c7e64c14aa))

--- a/packages/generator-one-app-module/package-lock.json
+++ b/packages/generator-one-app-module/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/generator-one-app-module",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/generator-one-app-module/package.json
+++ b/packages/generator-one-app-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/generator-one-app-module",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "generator for One App Modules",
   "license": "Apache-2.0",
   "contributors": [

--- a/packages/one-app-bundler/CHANGELOG.md
+++ b/packages/one-app-bundler/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [6.1.0](https://github.com/americanexpress/one-app-cli/compare/v6.0.0...v6.1.0) (2020-01-23)
+
+
+### Bug Fixes
+
+* **path:** ensure path to css-base.js is JSON.stringified ([#11](https://github.com/americanexpress/one-app-cli/issues/11)) ([3d4ff6b](https://github.com/americanexpress/one-app-cli/commit/3d4ff6babd3a0f42eb7235140630608e5028c1af)), closes [#10](https://github.com/americanexpress/one-app-cli/issues/10)
+
+
+### Features
+
+* **lerna:** upgrade lerna to v3.19.0 ([#9](https://github.com/americanexpress/one-app-cli/issues/9)) ([6dacd0b](https://github.com/americanexpress/one-app-cli/commit/6dacd0b8848d1f1045aff36fde2f0d441d0d49a2))
+* **one-app-bundler:** add chunk meta to one app build.meta file ([#14](https://github.com/americanexpress/one-app-cli/issues/14)) ([b8a9c3b](https://github.com/americanexpress/one-app-cli/commit/b8a9c3b740a00038d19f15fbbcf354d48a4d238c))

--- a/packages/one-app-bundler/package-lock.json
+++ b/packages/one-app-bundler/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@americanexpress/one-app-bundler",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-bundler",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "A command line interface(CLI) tool for bundling One App and its modules.",
   "main": "index.js",
   "bin": {
@@ -40,8 +40,8 @@
     "babel-eslint": "7.x || 8.x"
   },
   "dependencies": {
-    "@americanexpress/eslint-plugin-one-app": "^6.0.0",
-    "@americanexpress/one-app-locale-bundler": "^6.0.0",
+    "@americanexpress/eslint-plugin-one-app": "^6.1.0",
+    "@americanexpress/one-app-locale-bundler": "^6.1.0",
     "@americanexpress/purgecss-loader": "^1.0.0",
     "ajv": "^6.7.0",
     "babel-loader": "^8.0.6",

--- a/packages/one-app-locale-bundler/CHANGELOG.md
+++ b/packages/one-app-locale-bundler/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [6.1.0](https://github.com/americanexpress/one-app-cli/compare/v6.0.0...v6.1.0) (2020-01-23)
+
+
+### Features
+
+* **lerna:** upgrade lerna to v3.19.0 ([#9](https://github.com/americanexpress/one-app-cli/issues/9)) ([6dacd0b](https://github.com/americanexpress/one-app-cli/commit/6dacd0b8848d1f1045aff36fde2f0d441d0d49a2))

--- a/packages/one-app-locale-bundler/package-lock.json
+++ b/packages/one-app-locale-bundler/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@americanexpress/one-app-locale-bundler",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/one-app-locale-bundler/package.json
+++ b/packages/one-app-locale-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-locale-bundler",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "A command line interface(CLI) tool for bundling the locale files.",
   "bin": {
     "bundle-module-locale": "./bin/bundle-module-locale.js"


### PR DESCRIPTION
used `npm run lerna:version` to generate a changelog and iterate the version in all repos within one-app-cli. This is being done in order to tag and, once merged w/ master, publish all repos to npm.