### PR TITLE
fix(generator): add public access to publishConfig

### DIFF
--- a/packages/generator-one-app-module/package.json
+++ b/packages/generator-one-app-module/package.json
@@ -35,5 +35,8 @@
   "devDependencies": {
     "yeoman-assert": "^3.1.1",
     "yeoman-test": "^2.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
necessary in order to publish `generator-one-app-module` to npm registry.