### PR TITLE
docs(readme): update npx generator command

### DIFF
--- a/packages/generator-one-app-module/README.md
+++ b/packages/generator-one-app-module/README.md
@@ -7,7 +7,7 @@
 Assuming you have [npx installed](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) (comes with `npm` on versions 5.2.0 and above):
 
 ```bash
-npx -p yo -p @americanexpress/generator-one-app-module -- yo one-app-module
+npx -p yo -p @americanexpress/generator-one-app-module -- yo @americanexpress/one-app-module
 ```
 
 ## 🏆 Contributing


### PR DESCRIPTION
old npx command was faulty. The correct command (for our scoped library) is npx -p yo -p @americanexpress/generator-one-app-module -- yo @americanexpress/one-app-module