### PR TITLE
test(jest): add __tests__ directory for base-module

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
         "lines": 99.66,
         "functions": 97.37
       }
-    }
+    },
+    "testPathIgnorePatterns": [
+      "packages/generator-one-app-module/generators/app/templates"
+    ]
   },
   "husky": {
     "hooks": {

--- a/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/.eslintrc.json
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "amex/test"
+}

--- a/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/components/ModuleContainer.spec.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/components/ModuleContainer.spec.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import AppConfig from '../../src/appConfig';
+import <%=moduleNamePascal%> from '../../src/components/<%=moduleNamePascal%>';
+
+configure({ adapter: new Adapter() });
+
+describe('<%=moduleNamePascal%>', () => {
+  it('default export should return a function', () => {
+    expect(<%=moduleNamePascal%>).toBeInstanceOf(Function);
+  });
+
+  it('module should render correct JSX', () => {
+    const renderedModule = shallow(<<%=moduleNamePascal%> />);
+    expect(toJson(renderedModule)).toMatchSnapshot();
+  });
+
+  // test only necessary for root modules
+  it('appConfig should contain accurate csp', () => {
+    expect(AppConfig.csp).toBeDefined();
+    expect(typeof AppConfig.csp).toBe('string');
+  });
+});

--- a/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/components/ModuleContainer.spec.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/components/ModuleContainer.spec.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+
 import AppConfig from '../../src/appConfig';
 import <%=moduleNamePascal%> from '../../src/components/<%=moduleNamePascal%>';
-
-configure({ adapter: new Adapter() });
 
 describe('<%=moduleNamePascal%>', () => {
   it('default export should return a function', () => {

--- a/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/enzyme.config.js
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/enzyme.config.js
@@ -1,0 +1,4 @@
+import Adapter from 'enzyme-adapter-react-16';
+import { configure } from 'enzyme';
+
+configure({ adapter: new Adapter() });

--- a/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/index.spec.js
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/__tests__/index.spec.js
@@ -1,0 +1,8 @@
+import MainExport from '../src';
+import ModuleContainer from '../src/components/<%=moduleNamePascal%>';
+
+describe('index', () => {
+  it('should export the top component', () => {
+    expect(MainExport).toBe(ModuleContainer);
+  });
+});

--- a/packages/generator-one-app-module/generators/app/templates/base-module/enzyme.config.js
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/enzyme.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import Adapter from 'enzyme-adapter-react-16';
 import { configure } from 'enzyme';
 

--- a/packages/generator-one-app-module/generators/app/templates/base-module/package.json
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/package.json
@@ -30,5 +30,13 @@
     "eslint-config-amex": "^11.1.0",
     "jest": "^25.1.0",
     "rimraf": "^3.0.0"
+  },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "./__tests__/enzyme.config.js"
+    ],
+    "testPathIgnorePatterns": [
+      "./__tests__/enzyme.config.js"
+    ]
   }
 }

--- a/packages/generator-one-app-module/generators/app/templates/base-module/package.json
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/package.json
@@ -9,7 +9,8 @@
     "clean": "rimraf build",
     "prepare": "npm run build",
     "lint": "eslint --ignore-path .gitignore --ext js,jsx .",
-    "watch:build": "npm run build -- --watch"
+    "watch:build": "npm run build -- --watch",
+    "test": "jest"
   },
   "dependencies": {
     "@americanexpress/one-app-bundler": "^6.0.0",
@@ -22,8 +23,12 @@
   "devDependencies": {
     "babel-eslint": "^8.2.6",
     "babel-preset-amex": "^3.2.0",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.2",
+    "enzyme-to-json": "^3.4.4",
     "eslint": "^6.8.0",
     "eslint-config-amex": "^11.1.0",
+    "jest": "^25.1.0",
     "rimraf": "^3.0.0"
   }
 }

--- a/packages/generator-one-app-module/generators/app/templates/base-module/package.json
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/package.json
@@ -33,10 +33,7 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "./__tests__/enzyme.config.js"
-    ],
-    "testPathIgnorePatterns": [
-      "./__tests__/enzyme.config.js"
+      "./enzyme.config.js"
     ]
   }
 }

--- a/packages/generator-one-app-module/generators/app/templates/base-module/src/appConfig.js
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/src/appConfig.js
@@ -1,6 +1,7 @@
 import csp from './csp';
 
-// Read about appConfig: https://github.com/americanexpress/one-app#appconfig
-export default {
+// Read about appConfig:
+// https://github.com/americanexpress/one-app/blob/master/docs/api/modules/App-Configuration.md
+module.exports = {
   csp,
 };

--- a/packages/generator-one-app-module/generators/app/templates/base-module/src/appConfig.js
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/src/appConfig.js
@@ -2,6 +2,6 @@ import csp from './csp';
 
 // Read about appConfig:
 // https://github.com/americanexpress/one-app/blob/master/docs/api/modules/App-Configuration.md
-module.exports = {
+export default {
   csp,
 };

--- a/packages/generator-one-app-module/generators/app/templates/base-module/src/appConfig.js
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/src/appConfig.js
@@ -1,0 +1,6 @@
+import csp from './csp';
+
+// Read about appConfig: https://github.com/americanexpress/one-app#appconfig
+export default {
+  csp,
+};

--- a/packages/generator-one-app-module/generators/app/templates/base-module/src/components/ModuleContainer.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/src/components/ModuleContainer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from '@americanexpress/one-app-router';
-import csp from '../csp';
+import appConfig from '../appConfig';
 
 const <%=moduleNamePascal%> = () => (
   <div>
@@ -15,9 +15,7 @@ const <%=moduleNamePascal%> = () => (
 
 // Read about appConfig: https://github.com/americanexpress/one-app#appconfig
 if (!global.BROWSER) {
-  <%=moduleNamePascal%>.appConfig = {
-    csp,
-  };
+  <%=moduleNamePascal%>.appConfig = appConfig;
 }
 
 export default <%=moduleNamePascal%>;

--- a/packages/generator-one-app-module/generators/app/templates/base-module/src/components/ModuleContainer.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/src/components/ModuleContainer.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Route } from '@americanexpress/one-app-router';
-import appConfig from '../appConfig';
 
 const <%=moduleNamePascal%> = () => (
   <div>
@@ -8,14 +7,17 @@ const <%=moduleNamePascal%> = () => (
   </div>
 );
 
-// Read about childRoutes: https://github.com/americanexpress/one-app#routing
+// Read about childRoutes:
+// https://github.com/americanexpress/one-app/blob/master/docs/api/modules/Routing.md#childroutes
 <%=moduleNamePascal%>.childRoutes = () => ([
   <Route path="/" />,
 ]);
 
-// Read about appConfig: https://github.com/americanexpress/one-app#appconfig
+// Read about appConfig:
+// https://github.com/americanexpress/one-app/blob/master/docs/api/modules/App-Configuration.md
 if (!global.BROWSER) {
-  <%=moduleNamePascal%>.appConfig = appConfig;
+  // eslint-disable-next-line global-require
+  <%=moduleNamePascal%>.appConfig = require('../appConfig');
 }
 
 export default <%=moduleNamePascal%>;

--- a/packages/generator-one-app-module/generators/app/templates/base-module/src/components/ModuleContainer.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/src/components/ModuleContainer.jsx
@@ -17,7 +17,7 @@ const <%=moduleNamePascal%> = () => (
 // https://github.com/americanexpress/one-app/blob/master/docs/api/modules/App-Configuration.md
 if (!global.BROWSER) {
   // eslint-disable-next-line global-require
-  <%=moduleNamePascal%>.appConfig = require('../appConfig');
+  <%=moduleNamePascal%>.appConfig = require('../appConfig').default;
 }
 
 export default <%=moduleNamePascal%>;

--- a/packages/generator-one-app-module/generators/app/templates/base-module/src/csp.js
+++ b/packages/generator-one-app-module/generators/app/templates/base-module/src/csp.js
@@ -1,7 +1,8 @@
 import contentSecurityPolicyBuilder from 'content-security-policy-builder';
 import ip from 'ip';
 
-// Read about csp: https://github.com/americanexpress/one-app#csp
+// Read about csp:
+// https://github.com/americanexpress/one-app/blob/master/docs/api/modules/App-Configuration.md#csp
 export default contentSecurityPolicyBuilder({
   directives: {
     reportUri: `${process.env.ONE_CLIENT_REPORTING_URL}/report/security/csp-violation`,


### PR DESCRIPTION
adds rudimentary tests for a generated module.

a few considerations I've gone back and forth on related to the generator and this PR:

1) decided against creating a prompt for the user to choose between creating a `root module` and `child module`. The only difference between the two is the inclusion of `csp` in the appConfig, which the user will become aware of while reading the recipe docs. Providing the two separate options I think would cause confusion (especially at initial quick start) and force the generator to provide two separate scaffolds that only differ in a few lines of code.

2) unit tests have stayed very basic. I initially wrote tests that used `jest-json-schema` to type-check every property that could be added to appConfig, but since all properties but csp are optional, I think the better approach is to have the user incrementally add tests as they ramp up their own config. 

3) Internationalization isn't added to the module by default. This could be incorporated in a generator prompt in the future, but it significantly increases the complexity of the module (must bring in one-app-ducks, then holocron comes into the picture as well), and this takes away from our idea of having the quick start being bare-bones and simple. I think more discussions about what our goals are w/ the generator vs the docs need to happen before we move forward with dynamic generator features.