### PR TITLE
feat(app/webpack/client): use regenerator runtime in legacy only

### DIFF
--- a/packages/one-app-bundler/webpack/app/webpack.client.js
+++ b/packages/one-app-bundler/webpack/app/webpack.client.js
@@ -66,9 +66,8 @@ module.exports = (babelEnv) => merge(
     entry: {
       app: './src/client/client',
       vendors: [
-        ...(babelEnv !== 'modern' ? ['isomorphic-fetch', 'url-polyfill'] : []),
+        ...(babelEnv !== 'modern' ? ['isomorphic-fetch', 'url-polyfill', 'regenerator-runtime/runtime'] : []),
         ...(babelEnv !== 'modern' ? getCoreJsModulePaths(legacyBrowserList) : getCoreJsModulePaths(browserList)).map(resolve),
-        resolve('regenerator-runtime/runtime'),
         ...Object.keys(moduleExternals).map(resolve),
       ],
     },


### PR DESCRIPTION
- [ ] confirm this is not a breaking change