### PR TITLE
feat(one-app-bundler): use cross-fetch instead of isomorphic-fetch

### DIFF
--- a/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
@@ -51,12 +51,12 @@ describe('webpack/app', () => {
 
   it('should include a fetch polyfill for legacy browsers', () => {
     const webpackConfig = configGenerator('legacy');
-    expect(webpackConfig.entry.vendors.includes('isomorphic-fetch')).toBe(true);
+    expect(webpackConfig.entry.vendors.includes('cross-fetch')).toBe(true);
   });
 
   it('should not include a fetch polyfill for modern browsers', () => {
     const webpackConfig = configGenerator('modern');
-    expect(webpackConfig.entry.vendors.includes('isomorphic-fetch')).toBe(false);
+    expect(webpackConfig.entry.vendors.includes('cross-fetch')).toBe(false);
   });
 
   it('should use more core-js modules for legacy browsers than modern ones', () => {

--- a/packages/one-app-bundler/webpack/app/webpack.client.js
+++ b/packages/one-app-bundler/webpack/app/webpack.client.js
@@ -66,7 +66,7 @@ module.exports = (babelEnv) => merge(
     entry: {
       app: './src/client/client',
       vendors: [
-        ...(babelEnv !== 'modern' ? ['isomorphic-fetch', 'url-polyfill'] : []),
+        ...(babelEnv !== 'modern' ? ['cross-fetch', 'url-polyfill'] : []),
         ...(babelEnv !== 'modern' ? getCoreJsModulePaths(legacyBrowserList) : getCoreJsModulePaths(browserList)).map(resolve),
         resolve('regenerator-runtime/runtime'),
         ...Object.keys(moduleExternals).map(resolve),


### PR DESCRIPTION
[isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch/issues) has not been updated in almost 5 years. switching [cross-fetch](https://github.com/lquixada/cross-fetch) as it is actively maintained. Both fulfil the same role.