### PR TITLE
WIP: Feature/purgecss upgrade

### DIFF
--- a/packages/one-app-bundler/__tests__/webpack/loaders/__snapshots__/common.spec.js.snap
+++ b/packages/one-app-bundler/__tests__/webpack/loaders/__snapshots__/common.spec.js.snap
@@ -53,15 +53,61 @@ Object {
 }
 `;
 
+exports[`Common webpack loaders purgecss-loader should include any additional configured options 1`] = `
+Array [
+  Object {
+    "loader": "@americanexpress/purgecss-loader",
+    "options": Object {
+      "extractors": Array [
+        Object {
+          "extensions": Array [
+            "js",
+          ],
+          "extractor": "purgeJs",
+        },
+      ],
+      "fontFace": true,
+      "keyframes": true,
+      "paths": Array [
+        "/current/dir/src/**/*.{js,jsx}",
+        "foo",
+        "bar",
+      ],
+      "variables": true,
+      "whitelist": Array [
+        "random",
+        "yep",
+        "button",
+      ],
+      "whitelistPatterns": Array [
+        /red\\$/,
+      ],
+      "whitelistPatternsChildren": Array [
+        /blue\\$/,
+      ],
+    },
+  },
+]
+`;
+
 exports[`Common webpack loaders purgecss-loader should include any additional configured paths 1`] = `
 Array [
   Object {
     "loader": "@americanexpress/purgecss-loader",
     "options": Object {
+      "extractors": Array [],
+      "fontFace": false,
+      "keyframes": false,
       "paths": Array [
         "/current/dir/src/**/*.{js,jsx}",
         "foo",
         "bar",
+      ],
+      "variables": false,
+      "whitelist": Array [],
+      "whitelistPatterns": Array [],
+      "whitelistPatternsChildren": Array [
+        /:global\\$/,
       ],
     },
   },
@@ -73,8 +119,17 @@ Array [
   Object {
     "loader": "@americanexpress/purgecss-loader",
     "options": Object {
+      "extractors": Array [],
+      "fontFace": false,
+      "keyframes": false,
       "paths": Array [
         "/current/dir/src/**/*.{js,jsx}",
+      ],
+      "variables": false,
+      "whitelist": Array [],
+      "whitelistPatterns": Array [],
+      "whitelistPatternsChildren": Array [
+        /:global\\$/,
       ],
     },
   },

--- a/packages/one-app-bundler/__tests__/webpack/loaders/common.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/loaders/common.spec.js
@@ -69,6 +69,24 @@ describe('Common webpack loaders', () => {
       expect(purgeCssLoader()).toMatchSnapshot();
     });
 
+    it('should include any additional configured options', () => {
+      const purgecss = {
+        paths: ['foo', 'bar'],
+        extractors: [{
+          extractor: 'purgeJs',
+          extensions: ['js'],
+        }],
+        fontFace: true,
+        keyframes: true,
+        variables: true,
+        whitelist: ['random', 'yep', 'button'],
+        whitelistPatterns: [/red$/],
+        whitelistPatternsChildren: [/blue$/],
+      };
+      getConfigOptions.mockReturnValueOnce({ purgecss });
+      expect(purgeCssLoader()).toMatchSnapshot();
+    });
+
     it('should return an empty object when disabled', () => {
       getConfigOptions.mockReturnValueOnce({ purgecss: { disabled: true } });
       expect(purgeCssLoader()).toEqual([]);

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -33,7 +33,8 @@
     "Michael Tomcal <Michael.A.Tomcal@aexp.com> (https://github.com/mtomcal)",
     "Stephanie Coates  <Stephanie.Coates1@aexp.com> (https://github.com/stephaniecoates)",
     "Nelly Kiboi <Nelly.J.Kiboi@aexp.com> (https://github.com/nellyk)",
-    "Nickolas Oliver <nickolas.oliver@aexp.com> (https://github.com/PixnBits)"
+    "Nickolas Oliver <nickolas.oliver@aexp.com> (https://github.com/PixnBits)",
+    "Ruben Casas <ruben@infoxication.net> (https://github.com/infoxicator)"
   ],
   "license": "Apache-2.0",
   "peerDependencies": {

--- a/packages/one-app-bundler/webpack/loaders/common.js
+++ b/packages/one-app-bundler/webpack/loaders/common.js
@@ -35,6 +35,13 @@ const purgeCssLoader = () => {
     loader: '@americanexpress/purgecss-loader',
     options: {
       paths: [path.join(packageRoot, 'src/**/*.{js,jsx}'), ...(configOptions.purgecss.paths || [])],
+      extractors: configOptions.purgecss.extractors || [],
+      fontFace: configOptions.purgecss.fontFace || false,
+      keyframes: configOptions.purgecss.keyframes || false,
+      variables: configOptions.purgecss.variables || false,
+      whitelist: configOptions.purgecss.whitelist || [],
+      whitelistPatterns: configOptions.purgecss.whitelistPatterns || [],
+      whitelistPatternsChildren: configOptions.purgecss.whitelistPatternsChildren || [/:global$/],
     },
   }];
 };


### PR DESCRIPTION
This requires a new version of `purgecss-loader` once this PR is merged https://github.com/americanexpress/purgecss-loader/pull/9

- Added `purgecss` options to the common `webpack` loaders.
- Default options added as per the `purgecss` options documentation
- Added `whitelistPatternsChildren` default option as `[/:global$/]` so it doesn't remove global css wrapped in `:global {}` however this regular expression can be customised by module developers as per their needs.

