### PR TITLE
fix(generator): remove deprecated holocron api

### DIFF
--- a/packages/generator-one-app-module/generators/app/templates/base-child-module/package.json
+++ b/packages/generator-one-app-module/generators/app/templates/base-child-module/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@americanexpress/one-app-router": "^1.0.0",
-    "holocron": "^1.0.0",
+    "holocron": "^1.1.0",
     "react": "^16.12.0"
   },
   "devDependencies": {

--- a/packages/generator-one-app-module/generators/app/templates/intl-child-module/__tests__/components/ModuleContainer.spec.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/intl-child-module/__tests__/components/ModuleContainer.spec.jsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { fromJS } from 'immutable';
 import {
-  <%=moduleNamePascal%>, mapDispatchToProps, mapStateToProps, load,
+  <%=moduleNamePascal%>, mapDispatchToProps, mapStateToProps, loadModuleData,
 } from '../../src/components/<%=moduleNamePascal%>';
 
 jest.mock('@americanexpress/one-app-ducks', () => ({
@@ -118,11 +118,14 @@ describe('<%=moduleNamePascal%> should render as expected', () => {
     });
   });
 
-  describe('holocronModule load', () => {
-    it('should load language pack for <%=modulePackageName%> module', () => {
-      const mockDispatch = jest.fn();
-      load()(mockDispatch);
-      expect(mockDispatch.mock.calls[0][0]).toBe('I am loading the language pack for <%=modulePackageName%> and my fallback locale is en-US');
+  describe('loadModuleData', () => {
+    const fakeStore = {
+      dispatch: jest.fn((x) => x),
+    };
+    it('should load language pack for <%=modulePackageName%> module ', async () => {
+      const langPackAsyncState = await loadModuleData({ store: fakeStore });
+      expect(langPackAsyncState).toBe('I am loading the language pack for <%=modulePackageName%> and my fallback locale is en-US');
+      expect(fakeStore.dispatch).toHaveBeenCalledWith(langPackAsyncState);
     });
   });
 });

--- a/packages/generator-one-app-module/generators/app/templates/intl-child-module/src/components/ModuleContainer.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/intl-child-module/src/components/ModuleContainer.jsx
@@ -3,13 +3,11 @@ import PropTypes from 'prop-types';
 import { loadLanguagePack, updateLocale } from '@americanexpress/one-app-ducks';
 import { FormattedMessage, IntlProvider } from 'react-intl';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
 import { fromJS } from 'immutable';
 
 export const <%=moduleNamePascal%> = ({ switchLanguage, languageData, localeName }) => {
   const locales = ['en-US', 'en-CA', 'es-MX'];
-  // Read about loading async data: 
+  // Read about loading async data:
   // https://github.com/americanexpress/one-app/blob/master/docs/api/modules/Loading-Data.md
   // quick and dirty solution - implement based on your use case
   if (languageData.greeting) {
@@ -63,12 +61,11 @@ export const mapStateToProps = (state) => {
   };
 };
 
-export const load = () => (dispatch) => dispatch(loadLanguagePack('<%=modulePackageName%>', { fallbackLocale: 'en-US' }));
+export const loadModuleData = ({ store: { dispatch } }) => dispatch(loadLanguagePack('<%=modulePackageName%>', { fallbackLocale: 'en-US' }));
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  holocronModule({
-    name: '<%=modulePackageName%>',
-    load,
-  })
-)(<%=moduleNamePascal%>);
+<%=moduleNamePascal%>.holocron = {
+  name: '<%=modulePackageName%>',
+  loadModuleData,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(<%=moduleNamePascal%>);

--- a/packages/generator-one-app-module/generators/app/templates/intl-root-module/__tests__/components/ModuleContainer.spec.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/intl-root-module/__tests__/components/ModuleContainer.spec.jsx
@@ -5,7 +5,7 @@ import { fromJS } from 'immutable';
 import { Route } from '@americanexpress/one-app-router';
 import childRoutes from '../../src/childRoutes';
 import {
-  <%=moduleNamePascal%>, mapDispatchToProps, mapStateToProps, load,
+  <%=moduleNamePascal%>, mapDispatchToProps, mapStateToProps, loadModuleData,
 } from '../../src/components/<%=moduleNamePascal%>';
 
 jest.mock('@americanexpress/one-app-ducks', () => ({
@@ -127,11 +127,14 @@ describe('<%=moduleNamePascal%> should render as expected', () => {
     });
   });
 
-  describe('holocronModule load', () => {
-    it('should load language pack for <%=modulePackageName%> module', () => {
-      const mockDispatch = jest.fn();
-      load()(mockDispatch);
-      expect(mockDispatch.mock.calls[0][0]).toBe('I am loading the language pack for <%=modulePackageName%> and my fallback locale is en-US');
+  describe('loadModuleData', () => {
+    const fakeStore = {
+      dispatch: jest.fn((x) => x),
+    };
+    it('should load language pack for <%=modulePackageName%> module ', async () => {
+      const langPackAsyncState = await loadModuleData({ store: fakeStore });
+      expect(langPackAsyncState).toBe('I am loading the language pack for <%=modulePackageName%> and my fallback locale is en-US');
+      expect(fakeStore.dispatch).toHaveBeenCalledWith(langPackAsyncState);
     });
   });
 });

--- a/packages/generator-one-app-module/generators/app/templates/intl-root-module/src/components/ModuleContainer.jsx
+++ b/packages/generator-one-app-module/generators/app/templates/intl-root-module/src/components/ModuleContainer.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { loadLanguagePack, updateLocale } from '@americanexpress/one-app-ducks';
 import { FormattedMessage, IntlProvider } from 'react-intl';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
 import { fromJS } from 'immutable';
 import childRoutes from '../childRoutes';
 
@@ -74,12 +72,11 @@ export const mapStateToProps = (state) => {
   };
 };
 
-export const load = () => (dispatch) => dispatch(loadLanguagePack('<%=modulePackageName%>', { fallbackLocale: 'en-US' }));
+export const loadModuleData = ({ store: { dispatch } }) => dispatch(loadLanguagePack('<%=modulePackageName%>', { fallbackLocale: 'en-US' }));
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  holocronModule({
-    name: '<%=modulePackageName%>',
-    load,
-  })
-)(<%=moduleNamePascal%>);
+<%=moduleNamePascal%>.holocron = {
+  name: '<%=modulePackageName%>',
+  loadModuleData,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(<%=moduleNamePascal%>);


### PR DESCRIPTION
Removed `holocronModule` HOC from the following generators

- `int-child-module`
- `intl-root-module`

updated `base-child-module` holocron dependency to ^1.1.0