### PR TITLE
fix(url-loader): add missing dep of url-loader

### DIFF
--- a/packages/one-app-bundler/package-lock.json
+++ b/packages/one-app-bundler/package-lock.json
@@ -3937,6 +3937,19 @@
 				"brorand": "^1.0.1"
 			}
 		},
+		"mime-db": {
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+		},
+		"mime-types": {
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"requires": {
+				"mime-db": "1.44.0"
+			}
+		},
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -6069,6 +6082,71 @@
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
 					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
+		"url-loader": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.0.tgz",
+			"integrity": "sha512-IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==",
+			"requires": {
+				"loader-utils": "^2.0.0",
+				"mime-types": "^2.1.26",
+				"schema-utils": "^2.6.5"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+					"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"emojis-list": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+				},
+				"fast-deep-equal": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+				},
+				"json5": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
+				"loader-utils": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				},
+				"schema-utils": {
+					"version": "2.6.6",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+					"integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
+					"requires": {
+						"ajv": "^6.12.0",
+						"ajv-keywords": "^3.4.1"
+					}
 				}
 			}
 		},

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -69,6 +69,7 @@
     "ssri": "^7.1.0",
     "style-loader": "^1.0.0",
     "terser-webpack-plugin": "^2.1.0",
+    "url-loader": "^4.1.0",
     "webpack": "^4.29.0",
     "webpack-custom-chunk-id-plugin": "^1.0.3",
     "webpack-dynamic-public-path": "^1.0.4",


### PR DESCRIPTION
Currently we use `url-loader` for images https://github.com/americanexpress/one-app-cli/blob/master/packages/one-app-bundler/webpack/webpack.common.js#L64. However, `url-loader` is not a dependency of the bundler. This causes issues when you try to do `import image from './image.png';` and then use it like `<img src={image} />`.