### PR TITLE
chore(lerna): setup independent versioning for lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "6.6.0"
+  "version": "independent"
 }


### PR DESCRIPTION
This enables https://github.com/lerna/lerna/blob/master/README.md#independent-mode. We are currently running into an issue where every package is being bumped when only 1 package has changes. This is not good especially if one of our packages needs to make a major version bump and the others do not.