### PR TITLE
fix(one-app-bundler): maxEntrypointSize and increase default to 250e3

### DIFF
--- a/packages/one-app-bundler/README.md
+++ b/packages/one-app-bundler/README.md
@@ -99,7 +99,7 @@ already provided by One App, your build will fail.
 #### `performanceBudget`
 
 Set a custom [performance budget](https://webpack.js.org/configuration/performance/#performancemaxassetsize)
-for your client module build. The default value is `200e3`.
+for your client module build. The default value is `250e3` (244kB).
 
 ```json
 {

--- a/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
@@ -42,7 +42,7 @@ describe('webpack/module.client', () => {
     process.env.NODE_ENV = 'development';
     const webpackConfig = configGenerator();
     expect(webpackConfig.performance).toMatchObject({
-      maxAssetSize: 200e3,
+      maxAssetSize: 250e3,
       hints: 'warning',
     });
   });
@@ -51,7 +51,7 @@ describe('webpack/module.client', () => {
     process.env.NODE_ENV = 'production';
     const webpackConfig = configGenerator();
     expect(webpackConfig.performance).toMatchObject({
-      maxAssetSize: 200e3,
+      maxAssetSize: 250e3,
       hints: 'error',
     });
   });
@@ -62,6 +62,7 @@ describe('webpack/module.client', () => {
     const webpackConfig = configGenerator();
     expect(webpackConfig.performance).toMatchObject({
       maxAssetSize: 4103,
+      maxEntrypointSize: 4103,
       hints: 'error',
     });
   });

--- a/packages/one-app-bundler/webpack/module/webpack.client.js
+++ b/packages/one-app-bundler/webpack/module/webpack.client.js
@@ -58,7 +58,8 @@ module.exports = (babelEnv) => {
       },
       node: { module: 'empty', net: 'empty', fs: 'empty' },
       performance: {
-        maxAssetSize: configOptions.performanceBudget || 200e3,
+        maxAssetSize: configOptions.performanceBudget || 250e3,
+        maxEntrypointSize: configOptions.performanceBudget || 250e3,
         hints: process.env.NODE_ENV === 'development' ? 'warning' : 'error',
       },
       module: {


### PR DESCRIPTION
Added missing `maxEntrypointSize` to the webpack client configuration.

Changed the default value for both `maxAssetSize` and `maxEntrypointSize` to 250e3 instead of 200e3.

We previously discussed about increasing the default performance budget, and seems like the 250e3 is a sane default also used by `webpack` in their official docs 
https://webpack.js.org/configuration/performance/#performancemaxentrypointsize
