### PR TITLE
feat(one-app-runner): create network and env file

### DIFF
--- a/packages/one-app-runner/README.md
+++ b/packages/one-app-runner/README.md
@@ -347,7 +347,7 @@ This option is useful to run a test suite against the running One App container.
 ##### package.json
 ```json
 "scripts": {
-  "start": "one-app-runner"
+  "start": "one-app-runner",
   "start:test": "one-app-runner-test"
 },
 "one-amex": {

--- a/packages/one-app-runner/README.md
+++ b/packages/one-app-runner/README.md
@@ -232,7 +232,7 @@ Connect the One App container to a network. The value gets passed to the [docker
 Sample usage:
 
 ```bash
-npx @americanexpress/one-app-runner --root-module-name frank-lloyd-root --one-app-version 5.0.0 --module-map-url https://example.com/cdn/module-map.json  --module ../frank-lloyd-root --doker-network-to-join my-network
+npx @americanexpress/one-app-runner --root-module-name frank-lloyd-root --one-app-version 5.0.0 --module-map-url https://example.com/cdn/module-map.json  --module ../frank-lloyd-root --docker-network-to-join my-network
 ```
 
 Or in `package.json`
@@ -259,7 +259,7 @@ Creates a new [docker network](https://docs.docker.com/engine/reference/commandl
 Sample usage:
 
 ```bash
-npx @americanexpress/one-app-runner --root-module-name frank-lloyd-root --one-app-version 5.0.0 --module-map-url https://example.com/cdn/module-map.json  --module ../frank-lloyd-root --create-docker-network --doker-network-to-join my-network
+npx @americanexpress/one-app-runner --root-module-name frank-lloyd-root --one-app-version 5.0.0 --module-map-url https://example.com/cdn/module-map.json  --module ../frank-lloyd-root --create-docker-network --docker-network-to-join my-network
 ```
 
 Or in `package.json`

--- a/packages/one-app-runner/README.md
+++ b/packages/one-app-runner/README.md
@@ -247,6 +247,34 @@ Or in `package.json`
     "dockerNetworkToJoin": "my-network"
   }
 }
+
+```
+### create-docker-network [Optional]
+
+>This option requires `docker-network-to-join` to be used as the network name.
+
+Creates a new [docker network](https://docs.docker.com/engine/reference/commandline/network_create/) using the network name provided.
+
+
+Sample usage:
+
+```bash
+npx @americanexpress/one-app-runner --root-module-name frank-lloyd-root --one-app-version 5.0.0 --module-map-url https://example.com/cdn/module-map.json  --module ../frank-lloyd-root --create-docker-network --doker-network-to-join my-network
+```
+
+Or in `package.json`
+
+```json
+"one-amex": {
+  "runner": {
+    "modules": ["."],
+    "rootModuleName": "frank-lloyd-root",
+    "moduleMapUrl": "https://example.com/cdn/module-map.json",
+    "oneAppVersion": "5.0.0",
+    "dockerNetworkToJoin": "my-network",
+    "createDockerNetwork": true
+  }
+}
 ```
 
 ### use-host [Optional]
@@ -307,3 +335,43 @@ Or in `package.json`
 `one-app-runner` respects the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables and passes them down to the One App docker container.
 
 Make use of these environment variables if the remote module map or modules you want One App to use are inaccessible without the use of a proxy server.
+
+
+## Test Environment
+
+### one-app-runner-test
+
+Creates a new instance of **one-app-runner** that runs in the background detached from the parent process.
+This option is useful to run a test suite against the running One App container.
+
+##### package.json
+```json
+"scripts": {
+  "start": "one-app-runner"
+  "start:test": "one-app-runner-test"
+},
+"one-amex": {
+  "runner": {
+    "modules": ["."],
+    "rootModuleName": "frank-lloyd-root",
+    "moduleMapUrl": "https://example.com/cdn/module-map.json",
+    "dockerImage": "one-app-dev:5.0.0",
+    "parrotMiddleware": "./dev.middleware.js"
+  }
+}
+```
+### create-runner-env
+
+This command generates random ports and values for the following environment variables:
+
+``` bash 
+HTTP_PORT
+HTTP_ONE_APP_DEV_CDN_PORT
+HTTP_ONE_APP_DEV_PROXY_SERVER_PORT
+HTTP_METRICS_PORT
+NETWORK_NAME
+```
+
+It stores them in a `.env` file to be shared across the test environments and **one-app-runner** 
+
+This command should be executed before starting `one-app-runner-test`

--- a/packages/one-app-runner/__tests__/bin/__snapshots__/one-app-runner.spec.js.snap
+++ b/packages/one-app-runner/__tests__/bin/__snapshots__/one-app-runner.spec.js.snap
@@ -19,6 +19,8 @@ Array [
                             instance
   --output-file             File to redirect all stdout and stderr from One App
                             Container to                                [string]
+  --create-docker-network   Creates a new docker network
+                                                      [boolean] [default: false]
   --docker-network-to-join  Connect One App container to a docker network
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
@@ -53,6 +55,8 @@ Array [
                             instance
   --output-file             File to redirect all stdout and stderr from One App
                             Container to                                [string]
+  --create-docker-network   Creates a new docker network
+                                                      [boolean] [default: false]
   --docker-network-to-join  Connect One App container to a docker network
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
@@ -85,6 +89,8 @@ Array [
                             instance
   --output-file             File to redirect all stdout and stderr from One App
                             Container to                                [string]
+  --create-docker-network   Creates a new docker network
+                                                      [boolean] [default: false]
   --docker-network-to-join  Connect One App container to a docker network
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
@@ -104,6 +110,7 @@ Array [
   Array [
     Object {
       "appDockerImage": "one-app:5.0.0",
+      "createDockerNetwork": false,
       "devEndpointsFile": "/fake/path/to/fake-module/dev.endpoints.js",
       "dockerNetworkToJoin": "one-test-environment-1234",
       "envVars": "MY_ENV_VAR=value",
@@ -210,6 +217,8 @@ Array [
                             instance
   --output-file             File to redirect all stdout and stderr from One App
                             Container to                                [string]
+  --create-docker-network   Creates a new docker network
+                                                      [boolean] [default: false]
   --docker-network-to-join  Connect One App container to a docker network
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
@@ -326,6 +335,8 @@ Array [
                             instance
   --output-file             File to redirect all stdout and stderr from One App
                             Container to                                [string]
+  --create-docker-network   Creates a new docker network
+                                                      [boolean] [default: false]
   --docker-network-to-join  Connect One App container to a docker network
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for

--- a/packages/one-app-runner/__tests__/src/__snapshots__/startApp.spec.js.snap
+++ b/packages/one-app-runner/__tests__/src/__snapshots__/startApp.spec.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`startApp Displays an error if createNetwork fails: create network calls 1`] = `[Error: Error creating network]`;
+
+exports[`startApp creates a docker network when the flag is provided: create network calls 1`] = `
+Array [
+  Array [
+    Object {
+      "name": "one-test-environment-1234",
+    },
+  ],
+]
+`;
+
 exports[`startApp mounts and serves modules in docker run if module paths are provided 1`] = `"docker pull one-app:5.0.0 && docker run -t -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3005:3005 -e NODE_ENV=development    -v /path/to/module-a:/opt/module-workspace/module-a -v /path/to-module-b:/opt/module-workspace/to-module-b one-app:5.0.0 /bin/sh -c \\"npm run serve-module /opt/module-workspace/module-a &&npm run serve-module /opt/module-workspace/to-module-b &&   node lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  \\""`;
 
 exports[`startApp mounts and serves modules in docker run if module paths are provided and moduleMapUrl is not 1`] = `"docker pull one-app:5.0.0 && docker run -t -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3005:3005 -e NODE_ENV=development    -v /path/to/module-a:/opt/module-workspace/module-a -v /path/to-module-b:/opt/module-workspace/to-module-b one-app:5.0.0 /bin/sh -c \\"npm run serve-module /opt/module-workspace/module-a &&npm run serve-module /opt/module-workspace/to-module-b &&   node lib/server/index.js --root-module-name=frank-lloyd-root   \\""`;
@@ -15,6 +27,8 @@ exports[`startApp runs set dev endpoints command in docker run if dev endpoints 
 exports[`startApp runs set middleware command and starts one app with mock flag in docker run if parrot middleware file is provided 1`] = `"docker pull one-app:5.0.0 && docker run -t -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3005:3005 -e NODE_ENV=development    -v /path/to/module-a:/opt/module-workspace/module-a one-app:5.0.0 /bin/sh -c \\"npm run serve-module /opt/module-workspace/module-a && npm run set-middleware /opt/module-workspace/module-a/dev.middleware.js &&  node lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json -m \\""`;
 
 exports[`startApp sets the network to join if the network name is provided 1`] = `"docker pull one-app:5.0.0 && docker run -t -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3005:3005 -e NODE_ENV=development --network=one-test-environment-1234   -v /path/to/module-a:/opt/module-workspace/module-a one-app:5.0.0 /bin/sh -c \\"npm run serve-module /opt/module-workspace/module-a &&   node lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  \\""`;
+
+exports[`startApp should not create a network if the networkName is not provided: create network calls 1`] = `Array []`;
 
 exports[`startApp throws an error if command errors: onErrorFunction 1`] = `"Error running docker. Are you sure you have it installed? For installation and setup details see https://www.docker.com/products/docker-desktop"`;
 

--- a/packages/one-app-runner/__tests__/src/__snapshots__/startApp.spec.js.snap
+++ b/packages/one-app-runner/__tests__/src/__snapshots__/startApp.spec.js.snap
@@ -28,7 +28,7 @@ exports[`startApp runs set middleware command and starts one app with mock flag 
 
 exports[`startApp sets the network to join if the network name is provided 1`] = `"docker pull one-app:5.0.0 && docker run -t -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3005:3005 -e NODE_ENV=development --network=one-test-environment-1234   -v /path/to/module-a:/opt/module-workspace/module-a one-app:5.0.0 /bin/sh -c \\"npm run serve-module /opt/module-workspace/module-a &&   node lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  \\""`;
 
-exports[`startApp should not create a network if the networkName is not provided: create network calls 1`] = `Array []`;
+exports[`startApp should throw an error if createDockerNetwork is true but dockerNetworkToJoin is not provided: create network calls 1`] = `[Error: createDockerNetwork is true but dockerNetworkToJoin is undefined, please pass a valid network name]`;
 
 exports[`startApp throws an error if command errors: onErrorFunction 1`] = `"Error running docker. Are you sure you have it installed? For installation and setup details see https://www.docker.com/products/docker-desktop"`;
 

--- a/packages/one-app-runner/__tests__/src/startApp.spec.js
+++ b/packages/one-app-runner/__tests__/src/startApp.spec.js
@@ -143,15 +143,11 @@ describe('startApp', () => {
     expect(mockCreateNetwork.mock.calls).toMatchSnapshot('create network calls');
   });
 
-  it('should not create a network if the networkName is not provided', () => {
-    const mockCreateNetwork = jest.fn(() => Promise.resolve());
-    Docker.mockImplementation(() => ({
-      createNetwork: mockCreateNetwork,
-    }));
-    startApp({
+  it('should throw an error if createDockerNetwork is true but dockerNetworkToJoin is not provided', () => {
+    const startAppTest = startApp({
       moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], createDockerNetwork: true,
     });
-    expect(mockCreateNetwork.mock.calls).toMatchSnapshot('create network calls');
+    expect(startAppTest).rejects.toMatchSnapshot('create network calls');
   });
 
   it('Displays an error if createNetwork fails', () => {

--- a/packages/one-app-runner/__tests__/src/startApp.spec.js
+++ b/packages/one-app-runner/__tests__/src/startApp.spec.js
@@ -17,13 +17,14 @@
 const path = require('path');
 const fs = require('fs');
 const childProcess = require('child_process');
-
+const Docker = require('dockerode');
 
 const startApp = require('../../src/startApp');
 
 const pathToLogFile = path.join(__dirname, '..', 'fixtures', 'app.log');
 
 jest.mock('child_process', () => ({ spawn: jest.fn() }));
+jest.mock('dockerode');
 
 describe('startApp', () => {
   beforeEach(() => {
@@ -129,6 +130,39 @@ describe('startApp', () => {
       moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], dockerNetworkToJoin: 'one-test-environment-1234',
     });
     expect(mockSpawn.calls[0].command).toMatchSnapshot();
+  });
+
+  it('creates a docker network when the flag is provided', () => {
+    const mockCreateNetwork = jest.fn(() => Promise.resolve());
+    Docker.mockImplementation(() => ({
+      createNetwork: mockCreateNetwork,
+    }));
+    startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], createDockerNetwork: true, dockerNetworkToJoin: 'one-test-environment-1234',
+    });
+    expect(mockCreateNetwork.mock.calls).toMatchSnapshot('create network calls');
+  });
+
+  it('should not create a network if the networkName is not provided', () => {
+    const mockCreateNetwork = jest.fn(() => Promise.resolve());
+    Docker.mockImplementation(() => ({
+      createNetwork: mockCreateNetwork,
+    }));
+    startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], createDockerNetwork: true,
+    });
+    expect(mockCreateNetwork.mock.calls).toMatchSnapshot('create network calls');
+  });
+
+  it('Displays an error if createNetwork fails', () => {
+    const mockCreateNetwork = jest.fn(() => Promise.reject(new Error('Error creating network')));
+    Docker.mockImplementation(() => ({
+      createNetwork: mockCreateNetwork,
+    }));
+    startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], createDockerNetwork: true, dockerNetworkToJoin: 'one-test-environment-1234',
+    });
+    expect(mockCreateNetwork()).rejects.toMatchSnapshot('create network calls');
   });
 
   it('uses host instead of localhost when the useHost flag is passed', () => {

--- a/packages/one-app-runner/bin/create-runner-env.js
+++ b/packages/one-app-runner/bin/create-runner-env.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+const getPort = require('get-port');
+const uuid = require('uuid/v4');
+const fs = require('fs-extra');
+
+const createRunnerEnv = async () => {
+  const httpPort = await getPort();
+  const devCdnPort = await getPort();
+  const devProxyServer = await getPort();
+  const metricsPort = await getPort();
+  const networkName = `one-app-environment-${uuid()}`;
+
+  await fs.writeFile('.env',
+    `HTTP_PORT=${httpPort}
+HTTP_ONE_APP_DEV_CDN_PORT=${devCdnPort}
+NETWORK_NAME=${networkName}
+HTTP_ONE_APP_DEV_PROXY_SERVER_PORT=${devProxyServer}
+HTTP_METRICS_PORT=${metricsPort}
+  `);
+};
+
+
+createRunnerEnv().catch((error) => {
+  /* eslint-disable no-console */
+  console.log();
+  console.error('⚠️   Error creating environment variables: \n', error);
+  /* eslint-enable no-console */
+});

--- a/packages/one-app-runner/bin/one-app-runner-test.js
+++ b/packages/one-app-runner/bin/one-app-runner-test.js
@@ -17,5 +17,5 @@
 require('dotenv').config();
 const { spawn } = require('child_process');
 
-const command = `one-app-runner --output-file=one-app-test.log --createDockerNetwork --docker-network-to-join=${process.env.NETWORK_NAME} --use-host`;
+const command = `one-app-runner --output-file=one-app-test.log --create-docker-network --docker-network-to-join=${process.env.NETWORK_NAME} --use-host`;
 spawn(command, { shell: true, stdio: 'ignore', detached: true }).unref();

--- a/packages/one-app-runner/bin/one-app-runner-test.js
+++ b/packages/one-app-runner/bin/one-app-runner-test.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+require('dotenv').config();
+const { spawn } = require('child_process');
+
+const command = `one-app-runner --output-file=one-app-test.log --createDockerNetwork --docker-network-to-join=${process.env.NETWORK_NAME} --use-host`;
+spawn(command, { shell: true, stdio: 'ignore', detached: true }).unref();

--- a/packages/one-app-runner/bin/one-app-runner.js
+++ b/packages/one-app-runner/bin/one-app-runner.js
@@ -115,6 +115,11 @@ const createYargsConfig = () => {
       describe: 'File to redirect all stdout and stderr from One App Container to',
       coerce: (value) => path.resolve(process.cwd(), value),
     })
+    .option('create-docker-network', {
+      default: false,
+      type: 'boolean',
+      describe: 'Creates a new docker network',
+    })
     .option('docker-network-to-join', {
       type: 'string',
       describe: 'Connect One App container to a docker network',
@@ -150,6 +155,7 @@ try {
     appDockerImage: argv.dockerImage,
     envVars: argv.envVars,
     outputFile: argv.outputFile,
+    createDockerNetwork: argv.createDockerNetwork,
     dockerNetworkToJoin: argv.dockerNetworkToJoin,
     useHost: argv.useHost,
   });

--- a/packages/one-app-runner/package-lock.json
+++ b/packages/one-app-runner/package-lock.json
@@ -23,10 +23,65 @@
         "color-convert": "^2.0.1"
       }
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "cliui": {
       "version": "6.0.0",
@@ -51,15 +106,68 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "docker-modem": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-2.1.3.tgz",
+      "integrity": "sha512-cwaRptBmYZwu/FyhGcqBm2MzXA77W2/E6eVkpOZVDk6PkI9Bjj84xPrXiHMA+OWjzNy+DFjgKh8Q+1hMR7/OHg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^0.8.7"
+      }
+    },
+    "dockerode": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.2.0.tgz",
+      "integrity": "sha512-C+y/W4Kks7YLBsfUOTMkk1IVilb4cdj+rE+UZ5hnE+rpcn2frSs7kX+6H8GteTqHcv8sln+GyxuP1qdno3IzIw==",
+      "requires": {
+        "concat-stream": "~2.0.0",
+        "docker-modem": "^2.1.0",
+        "tar-fs": "~2.0.1"
+      }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "find-up": {
       "version": "4.1.0",
@@ -70,15 +178,60 @@
         "path-exists": "^4.0.0"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",
@@ -88,6 +241,11 @@
         "p-locate": "^4.1.0"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "mock-spawn": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/mock-spawn/-/mock-spawn-0.2.6.tgz",
@@ -95,6 +253,19 @@
       "dev": true,
       "requires": {
         "through": "2.3.x"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
       }
     },
     "p-limit": {
@@ -163,6 +334,25 @@
         }
       }
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -173,10 +363,48 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY="
+    },
+    "ssh2": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
+      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "requires": {
+        "ssh2-streams": "~0.4.10"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
+      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
+      "requires": {
+        "asn1": "~0.2.0",
+        "bcrypt-pbkdf": "^1.0.2",
+        "streamsearch": "~0.1.2"
+      }
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string-width": {
       "version": "4.2.0",
@@ -188,6 +416,14 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -196,11 +432,59 @@
         "ansi-regex": "^5.0.0"
       }
     },
+    "tar-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "requires": {
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "which-module": {
       "version": "2.0.0",
@@ -216,6 +500,11 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
       }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "y18n": {
       "version": "4.0.0",

--- a/packages/one-app-runner/package.json
+++ b/packages/one-app-runner/package.json
@@ -14,7 +14,9 @@
     "Nelly Kiboi <Nelly.J.Kiboi@aexp.com> (https://github.com/nellyk)"
   ],
   "bin": {
-    "one-app-runner": "./bin/one-app-runner.js"
+    "one-app-runner": "./bin/one-app-runner.js",
+    "create-runner-env": "./bin/create-runner-env.js",
+    "one-app-runner-test": "bin/one-app-runner-test.js"
   },
   "files": [
     "src",
@@ -30,7 +32,12 @@
     "docker"
   ],
   "dependencies": {
+    "dockerode": "^3.2.0",
+    "dotenv": "^8.2.0",
+    "fs-extra": "^9.0.1",
+    "get-port": "^5.1.1",
     "pkg-up": "^3.1.0",
+    "uuid": "^3.3.2",
     "yargs": "^15.3.0"
   },
   "devDependencies": {

--- a/packages/one-app-runner/src/startApp.js
+++ b/packages/one-app-runner/src/startApp.js
@@ -94,7 +94,12 @@ module.exports = async function startApp({
 
   const generateModuleMap = () => (moduleMapUrl ? `--module-map-url=${moduleMapUrl}` : '');
 
-  if (createDockerNetwork && dockerNetworkToJoin) {
+  if (createDockerNetwork) {
+    if (!dockerNetworkToJoin) {
+      throw new Error(
+        'createDockerNetwork is true but dockerNetworkToJoin is undefined, please pass a valid network name'
+      );
+    }
     try {
       const docker = new Docker();
       await docker.createNetwork({ name: dockerNetworkToJoin });

--- a/packages/one-app-runner/src/startApp.js
+++ b/packages/one-app-runner/src/startApp.js
@@ -15,6 +15,7 @@
 const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const Docker = require('dockerode');
 
 module.exports = async function startApp({
   moduleMapUrl,
@@ -25,6 +26,7 @@ module.exports = async function startApp({
   outputFile,
   parrotMiddlewareFile,
   devEndpointsFile,
+  createDockerNetwork,
   dockerNetworkToJoin,
   useHost,
 }) {
@@ -91,6 +93,18 @@ module.exports = async function startApp({
   };
 
   const generateModuleMap = () => (moduleMapUrl ? `--module-map-url=${moduleMapUrl}` : '');
+
+  if (createDockerNetwork && dockerNetworkToJoin) {
+    try {
+      const docker = new Docker();
+      await docker.createNetwork({ name: dockerNetworkToJoin });
+    } catch (e) {
+      throw new Error(
+        `Error creating docker network ${e}`
+      );
+    }
+  }
+
   const generateNetworkToJoin = () => (dockerNetworkToJoin ? `--network=${dockerNetworkToJoin}` : '');
   const generateUseHostFlag = () => (useHost ? '--use-host' : '');
   const appPort = process.env.HTTP_PORT || 3000;


### PR DESCRIPTION
1. Accepts a new flag: createDockerNetwork
2. Creates a new command: `one-app-runner-test` that starts one-app in the background, using the host and connected to a network ready to run tests
3. Adds a new command: `create-runner-env` that creates a random network name and checks for available ports
