### PR TITLE
fix(css-loader): add import loaders count

### DIFF
--- a/packages/one-app-bundler/__tests__/webpack/loaders/__snapshots__/common.spec.js.snap
+++ b/packages/one-app-bundler/__tests__/webpack/loaders/__snapshots__/common.spec.js.snap
@@ -26,6 +26,7 @@ exports[`Common webpack loaders css-loader should still return a good localIdent
 Object {
   "loader": "css-loader",
   "options": Object {
+    "importLoaders": 2,
     "modules": Object {
       "localIdentName": "[name]__[local]___[hash:base64:5]",
     },
@@ -37,6 +38,7 @@ exports[`Common webpack loaders css-loader should use the chunk name in the loca
 Object {
   "loader": "css-loader",
   "options": Object {
+    "importLoaders": 2,
     "modules": Object {
       "localIdentName": "my-chunk__[name]__[local]___[hash:base64:5]",
     },
@@ -48,6 +50,7 @@ exports[`Common webpack loaders css-loader should use the css-loader 1`] = `
 Object {
   "loader": "css-loader",
   "options": Object {
+    "importLoaders": 2,
     "modules": Object {
       "localIdentName": "[name]__[local]___[hash:base64:5]",
     },

--- a/packages/one-app-bundler/webpack/app/webpack.client.js
+++ b/packages/one-app-bundler/webpack/app/webpack.client.js
@@ -99,7 +99,7 @@ module.exports = (babelEnv) => merge(
           test: /\.s?css$/,
           use: [
             { loader: 'style-loader' },
-            cssLoader(),
+            cssLoader({ importLoaders: 1 }),
             sassLoader(),
           ],
         },

--- a/packages/one-app-bundler/webpack/loaders/common.js
+++ b/packages/one-app-bundler/webpack/loaders/common.js
@@ -19,9 +19,10 @@ const getConfigOptions = require('../../utils/getConfigOptions');
 
 const packageRoot = process.cwd();
 
-const cssLoader = ({ name = '' } = {}) => ({
+const cssLoader = ({ name = '', importLoaders = 2 } = {}) => ({
   loader: 'css-loader',
   options: {
+    importLoaders,
     modules: {
       localIdentName: `${name && `${name}__`}[name]__[local]___[hash:base64:5]`,
     },


### PR DESCRIPTION
[`css-loader`](https://github.com/webpack-contrib/css-loader) should have the option [`importLoaders`](https://github.com/webpack-contrib/css-loader#importloaders) set if used with other loaders per rule. Relates to #79