### PR TITLE
fix(bundler): fix an issue with requiredExternals

### DIFF
--- a/packages/one-app-bundler/__tests__/utils/__snapshots__/extendWebpackConfig.spec.js.snap
+++ b/packages/one-app-bundler/__tests__/utils/__snapshots__/extendWebpackConfig.spec.js.snap
@@ -20,7 +20,7 @@ Object {
 
 exports[`extendWebpackConfig should use the provided requiredExternals configured 1`] = `
 Object {
-  "test": StringMatching /ajv\\$/,
+  "test": StringMatching /ajv/,
   "use": Array [
     Object {
       "loader": "@americanexpress/one-app-bundler/webpack/loaders/externals-loader",
@@ -34,7 +34,7 @@ Object {
 
 exports[`extendWebpackConfig should use the provided requiredExternals configured 2`] = `
 Object {
-  "test": StringMatching /lodash\\$/,
+  "test": StringMatching /lodash/,
   "use": Array [
     Object {
       "loader": "@americanexpress/one-app-bundler/webpack/loaders/externals-loader",

--- a/packages/one-app-bundler/__tests__/utils/extendWebpackConfig.spec.js
+++ b/packages/one-app-bundler/__tests__/utils/extendWebpackConfig.spec.js
@@ -112,12 +112,13 @@ describe('extendWebpackConfig', () => {
     getConfigOptions.mockReturnValueOnce({ requiredExternals: ['ajv', 'lodash'] });
     const result = extendWebpackConfig(originalWebpackConfig);
     const { rules } = result.module;
+    console.log('Rules: ', rules);
     expect(rules).toHaveLength(originalWebpackConfig.module.rules.length + 3);
     expect(rules[rules.length - 3]).toMatchSnapshot({
-      test: expect.stringMatching(/ajv$/),
+      test: expect.stringMatching(/ajv/),
     });
     expect(rules[rules.length - 2]).toMatchSnapshot({
-      test: expect.stringMatching(/lodash$/),
+      test: expect.stringMatching(/lodash/),
     });
     expect(rules[rules.length - 1]).toMatchSnapshot();
   });

--- a/packages/one-app-bundler/__tests__/utils/extendWebpackConfig.spec.js
+++ b/packages/one-app-bundler/__tests__/utils/extendWebpackConfig.spec.js
@@ -112,7 +112,7 @@ describe('extendWebpackConfig', () => {
     getConfigOptions.mockReturnValueOnce({ requiredExternals: ['ajv', 'lodash'] });
     const result = extendWebpackConfig(originalWebpackConfig);
     const { rules } = result.module;
-    console.log('Rules: ', rules);
+
     expect(rules).toHaveLength(originalWebpackConfig.module.rules.length + 3);
     expect(rules[rules.length - 3]).toMatchSnapshot({
       test: expect.stringMatching(/ajv/),

--- a/packages/one-app-bundler/utils/extendWebpackConfig.js
+++ b/packages/one-app-bundler/utils/extendWebpackConfig.js
@@ -72,7 +72,7 @@ function extendWebpackConfig(webpackConfig, bundleTarget) {
     customWebpackConfig = merge(customWebpackConfig, {
       module: {
         rules: [...requiredExternals.map((externalName) => ({
-          test: resolve(externalName),
+          test: `${resolve(externalName)}/`,
           use: [{
             loader: '@americanexpress/one-app-bundler/webpack/loaders/externals-loader',
             options: {
@@ -117,6 +117,8 @@ function extendWebpackConfig(webpackConfig, bundleTarget) {
       },
     });
   }
+
+  // console.log(JSON.stringify(merge(webpackConfig, customWebpackConfig)));
 
   return merge(webpackConfig, customWebpackConfig);
 }

--- a/packages/one-app-bundler/utils/extendWebpackConfig.js
+++ b/packages/one-app-bundler/utils/extendWebpackConfig.js
@@ -118,8 +118,6 @@ function extendWebpackConfig(webpackConfig, bundleTarget) {
     });
   }
 
-  // console.log(JSON.stringify(merge(webpackConfig, customWebpackConfig)));
-
   return merge(webpackConfig, customWebpackConfig);
 }
 


### PR DESCRIPTION
There was an issue where if a library like iguazu was listed ahead of a library
like iguazu-rpc, iguazu was getting bundled instead of iguazu-rpc.