### PR TITLE
fix(generator): react-intl in externals

### DIFF
--- a/packages/generator-one-app-module/__tests__/app.js
+++ b/packages/generator-one-app-module/__tests__/app.js
@@ -136,7 +136,7 @@ describe('generator-one-app-module', () => {
       assert.jsonFileContent('package.json', {
         'one-amex': {
           bundler: {
-            externals: 'react-intl',
+            requiredExternals: ['react-intl'],
           },
         },
       });
@@ -199,7 +199,7 @@ describe('generator-one-app-module', () => {
       assert.jsonFileContent('package.json', {
         'one-amex': {
           bundler: {
-            providesExternals: 'react-intl',
+            providedExternals: ['react-intl'],
           },
         },
       });

--- a/packages/generator-one-app-module/generators/app/index.js
+++ b/packages/generator-one-app-module/generators/app/index.js
@@ -186,7 +186,7 @@ module.exports = class extends Generator {
         this.fs.extendJSON(this.destinationPath('package.json'), {
           'one-amex': {
             bundler: {
-              externals: 'react-intl',
+              requiredExternals: ['react-intl'],
             },
           },
         });
@@ -205,7 +205,7 @@ module.exports = class extends Generator {
         this.fs.extendJSON(this.destinationPath('package.json'), {
           'one-amex': {
             bundler: {
-              providesExternals: 'react-intl',
+              providedExternals: ['react-intl'],
             },
           },
         });

--- a/packages/one-app-bundler/__tests__/webpack/module/webpack.server.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/module/webpack.server.spec.js
@@ -14,6 +14,10 @@
 
 jest.spyOn(process, 'cwd').mockImplementation(() => __dirname.split('/__tests__')[0]);
 
+jest.mock('read-pkg-up', () => ({
+  sync: jest.fn(() => ({ pkg: { name: '@americanexpress/one-app-bundler', version: '6.8.0' } })),
+}));
+
 const webpackConfig = require('../../../webpack/module/webpack.server');
 const { validateWebpackConfig } = require('../../../test-utils');
 


### PR DESCRIPTION
Fixed correct syntax for `providedExternals` to be an array of strings instead of a string.

Fixed issue with side effect in tests for one-app-bundler