### PR TITLE
feat(generator): add one-app-runner script

### DIFF
--- a/packages/generator-one-app-module/__tests__/app.js
+++ b/packages/generator-one-app-module/__tests__/app.js
@@ -245,7 +245,7 @@ describe('generator-one-app-module', () => {
           },
         },
         devDependencies: {
-          'parrot-middleware': '^4.1.0',
+          'parrot-middleware': '^3.1.0',
         },
       });
     });
@@ -291,7 +291,7 @@ describe('generator-one-app-module', () => {
           },
         },
         devDependencies: {
-          'parrot-middleware': '^4.1.0',
+          'parrot-middleware': '^3.1.0',
         },
       });
     });

--- a/packages/generator-one-app-module/__tests__/app.js
+++ b/packages/generator-one-app-module/__tests__/app.js
@@ -245,7 +245,7 @@ describe('generator-one-app-module', () => {
           },
         },
         devDependencies: {
-          'parrot-middleware': '^3.1.0',
+          'parrot-middleware': '^4.1.1',
         },
       });
     });

--- a/packages/generator-one-app-module/__tests__/app.js
+++ b/packages/generator-one-app-module/__tests__/app.js
@@ -291,7 +291,7 @@ describe('generator-one-app-module', () => {
           },
         },
         devDependencies: {
-          'parrot-middleware': '^3.1.0',
+          'parrot-middleware': '^4.1.1',
         },
       });
     });

--- a/packages/generator-one-app-module/generators/app/index.js
+++ b/packages/generator-one-app-module/generators/app/index.js
@@ -145,6 +145,11 @@ module.exports = class extends Generator {
         { globOptions: { dot: true } }
       );
       this.fs.extendJSON(this.destinationPath('package.json'), {
+        'one-amex': {
+          runner: {
+            rootModuleName: this.modulePackageName,
+          },
+        },
         dependencies: {
           'content-security-policy-builder': '^2.1.0',
         },
@@ -204,6 +209,9 @@ module.exports = class extends Generator {
         );
         this.fs.extendJSON(this.destinationPath('package.json'), {
           'one-amex': {
+            runner: {
+              rootModuleName: this.modulePackageName,
+            },
             bundler: {
               providesExternals: 'react-intl',
             },
@@ -220,7 +228,7 @@ module.exports = class extends Generator {
           },
         },
         devDependencies: {
-          'parrot-middleware': '^4.1.0',
+          'parrot-middleware': '^3.1.0',
         },
       });
     } else {

--- a/packages/generator-one-app-module/generators/app/index.js
+++ b/packages/generator-one-app-module/generators/app/index.js
@@ -228,7 +228,7 @@ module.exports = class extends Generator {
           },
         },
         devDependencies: {
-          'parrot-middleware': '^3.1.0',
+          'parrot-middleware': '^4.1.1',
         },
       });
     } else {

--- a/packages/generator-one-app-module/generators/app/templates/base-child-module/package.json
+++ b/packages/generator-one-app-module/generators/app/templates/base-child-module/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "contributors": [],
   "scripts": {
+    "start": "one-app-runner",
     "prebuild": "npm run clean",
     "build": "bundle-module",
     "watch:build": "npm run build -- --watch",
@@ -13,6 +14,12 @@
     "test:unit": "jest",
     "test": "npm run test:lint && npm run test:unit"
   },
+  "one-amex": {
+    "runner": {
+      "dockerImage": "oneamex/one-app-dev:latest",
+      "modules": ["."]
+    }
+  },
   "dependencies": {
     "@americanexpress/one-app-router": "^1.0.0",
     "holocron": "^1.1.0",
@@ -20,6 +27,7 @@
   },
   "devDependencies": {
     "@americanexpress/one-app-bundler": "^6.0.0",
+    "@americanexpress/one-app-runner": "^6.0.0",
     "amex-jest-preset-react": "^6.0.0",
     "babel-eslint": "^8.2.6",
     "babel-preset-amex": "^3.2.0",


### PR DESCRIPTION
Add `npm start` to use `one-app-runner` pointing at the latest one-app-dev docker image.

Also downgraded the parrot-middleware version due to a current issue with commonjs export