### PR TITLE
feat(generator): adds .build-cache to gitignore

### DIFF
--- a/packages/generator-one-app-module/generators/app/templates/base-child-module/gitignore
+++ b/packages/generator-one-app-module/generators/app/templates/base-child-module/gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # build
 build
+.build-cache
 .webpack-stats*
 bundle.integrity.manifest.json
 


### PR DESCRIPTION
A `.build-cache` directory is generated by One App. This PR adds it to the `.gitignore` for the yeoman generator.