### PR TITLE
docs(recipes): add one-app-runner recipe

### DIFF
--- a/packages/one-app-runner/docs/recipes/README.md
+++ b/packages/one-app-runner/docs/recipes/README.md
@@ -1,0 +1,7 @@
+[👈 Return to README](../../README.md)
+
+# 👩‍🍳 Recipes
+
+* [Using with Windows](./Using-With-Windows.md)
+
+[☝️ Return To Top](#-recipes)

--- a/packages/one-app-runner/docs/recipes/Using-With-Windows.md
+++ b/packages/one-app-runner/docs/recipes/Using-With-Windows.md
@@ -13,7 +13,7 @@ Since `one-app-runner` uses Docker, you will need to install Docker on your Wind
 
 ## Download Docker Desktop
 
-If you haven't downloaded Docker, go ahead and [download for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows) Docker.
+If you haven't downloaded Docker, go ahead and [download Docker for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows).
 
 ## Start Docker Desktop
 

--- a/packages/one-app-runner/docs/recipes/Using-With-Windows.md
+++ b/packages/one-app-runner/docs/recipes/Using-With-Windows.md
@@ -2,7 +2,7 @@
 
 ## System Requirements
 
-Since `one-app-runner` uses Docker, you will need to install Docker on your Windows machine. Due to this, you need the following requirements:
+Since `one-app-runner` uses Docker, you will need to install Docker on your Windows machine. You need the following requirements:
 
 * Windows 10 64-bit: Pro, Enterprise, Education (Build 16299 or later), Home (Version 2004 or higher)
 * Hyper-V enabled
@@ -13,7 +13,7 @@ Since `one-app-runner` uses Docker, you will need to install Docker on your Wind
 
 ## Download Docker Desktop
 
-If you haven't download Docker, go ahead and [download for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows) Docker.
+If you haven't downloaded Docker, go ahead and [download for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows) Docker.
 
 ## Start Docker Desktop
 

--- a/packages/one-app-runner/docs/recipes/Using-With-Windows.md
+++ b/packages/one-app-runner/docs/recipes/Using-With-Windows.md
@@ -1,0 +1,24 @@
+# Using with Windows
+
+## System Requirements
+
+Since `one-app-runner` uses Docker, you will need to install Docker on your Windows machine. Due to this, you need the following requirements:
+
+* Windows 10 64-bit: Pro, Enterprise, Education (Build 16299 or later), Home (Version 2004 or higher)
+* Hyper-V enabled
+* If on Windows Home, enable the WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+* The following hardware prerequisites are required to successfully run WSL 2 on Windows 10 Home:
+  * 64 bit processor with Second Level Address Translation (SLAT)
+  * 4GB system RAM
+
+## Download Docker Desktop
+
+If you haven't download Docker, go ahead and [download for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows) Docker.
+
+## Start Docker Desktop
+
+Docker desktop does not start automatically after install. To start Docker Desktop, search for Docker, and select Docker Desktop in the search results. When the whale icon in the status bar stays steady, Docker Desktop is up-and-running, and is available in any terminal window.
+
+## Use `one-app-runner`
+
+Congratulations! You are now ready to use `one-app-runner` within your modules for local development!


### PR DESCRIPTION
Just a very basic how to get docker on windows up and running. After installing docker for Windows it is no different than running on Linux or macOS (in my experience)