### PR TITLE
chore(release): add message when running lerna:version locally

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,8 @@
   ],
   "command": {
     "version": {
-      "conventionalCommits": true
+      "conventionalCommits": true,
+       "message": "chore(release): publish %s"
     }
   },
   "version": "independent"


### PR DESCRIPTION
This would add a default message when running `npm run lerna:version` to prevent the precommit messages from failing
https://github.com/lerna/lerna/tree/master/commands/version#--message-msg