### PR TITLE
feat(sass): allow the use of sass files

### DIFF
--- a/packages/one-app-bundler/webpack/app/webpack.client.js
+++ b/packages/one-app-bundler/webpack/app/webpack.client.js
@@ -96,7 +96,7 @@ module.exports = (babelEnv) => merge(
           exclude: new RegExp(`^${path.resolve(packageRoot, 'node_modules', 'core-js')}`),
           use: [babelLoader(babelEnv)],
         }, {
-          test: /\.s?css$/,
+          test: /\.(sa|sc|c)ss$/,
           use: [
             { loader: 'style-loader' },
             cssLoader({ importLoaders: 1 }),

--- a/packages/one-app-bundler/webpack/module/webpack.client.js
+++ b/packages/one-app-bundler/webpack/module/webpack.client.js
@@ -70,7 +70,7 @@ module.exports = (babelEnv) => {
             use: [babelLoader(babelEnv)],
           },
           {
-            test: /\.s?css$/,
+            test: /\.(sa|sc|c)ss$/,
             use: [
               { loader: 'style-loader' },
               cssLoader({ name }),

--- a/packages/one-app-bundler/webpack/module/webpack.server.js
+++ b/packages/one-app-bundler/webpack/module/webpack.server.js
@@ -54,7 +54,7 @@ module.exports = extendWebpackConfig(merge(
           use: [babelLoader()],
         },
         {
-          test: /\.s?css$/,
+          test: /\.(sa|sc|c)ss$/,
           use: [
             {
               loader: '@americanexpress/one-app-bundler/webpack/loaders/ssr-css-loader', options: { name },


### PR DESCRIPTION
Tested with the following 

```jsx
export const MyRoot = () => (
  <nav>
    <ul>
      <li>
        <a>Test</a>
      </li>
    </ul>
  </nav>
);
```

```sass
nav
  ul
    margin: 0
    padding: 0
    list-style: none

  li
    display: inline-block

  a
    display: block
    padding: 6px 12px
    text-decoration: none
```