### PR TITLE
fix(fetch): cross-fetch and abort-controller polyfills

### DIFF
--- a/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
@@ -51,12 +51,22 @@ describe('webpack/app', () => {
 
   it('should include a fetch polyfill for legacy browsers', () => {
     const webpackConfig = configGenerator('legacy');
-    expect(webpackConfig.entry.vendors.includes('cross-fetch')).toBe(true);
+    expect(webpackConfig.entry.vendors.includes('cross-fetch/polyfill')).toBe(true);
   });
 
   it('should not include a fetch polyfill for modern browsers', () => {
     const webpackConfig = configGenerator('modern');
-    expect(webpackConfig.entry.vendors.includes('cross-fetch')).toBe(false);
+    expect(webpackConfig.entry.vendors.includes('cross-fetch/polyfill')).toBe(false);
+  });
+
+  it('should include abort-controller polyfill for legacy browsers', () => {
+    const webpackConfig = configGenerator('legacy');
+    expect(webpackConfig.entry.vendors.includes('abort-controller/polyfill')).toBe(true);
+  });
+
+  it('should not include abort-controller polyfill for modern browsers', () => {
+    const webpackConfig = configGenerator('modern');
+    expect(webpackConfig.entry.vendors.includes('abort-controller/polyfill')).toBe(false);
   });
 
   it('should use more core-js modules for legacy browsers than modern ones', () => {

--- a/packages/one-app-bundler/webpack/app/webpack.client.js
+++ b/packages/one-app-bundler/webpack/app/webpack.client.js
@@ -66,7 +66,7 @@ module.exports = (babelEnv) => merge(
     entry: {
       app: './src/client/client',
       vendors: [
-        ...(babelEnv !== 'modern' ? ['cross-fetch', 'url-polyfill'] : []),
+        ...(babelEnv !== 'modern' ? ['cross-fetch/polyfill', 'url-polyfill', 'abort-controller/polyfill'] : []),
         ...(babelEnv !== 'modern' ? getCoreJsModulePaths(legacyBrowserList) : getCoreJsModulePaths(browserList)).map(resolve),
         resolve('regenerator-runtime/runtime'),
         ...Object.keys(moduleExternals).map(resolve),


### PR DESCRIPTION
Add `cross-fetch/polyfill` and `abort-controller/polyfill` to the legacy bundle of the app.

Tested using npm pack and installing this bundler version to one app, making a client side fetch call no longer results in errors from the `app.js` bundle when running on IE11