### PR TITLE
feat(runner): add offline flag

### DIFF
--- a/packages/one-app-runner/README.md
+++ b/packages/one-app-runner/README.md
@@ -303,6 +303,30 @@ Or in `package.json`
 }
 ```
 
+### offline [Optional]
+
+Bypass `docker pull` and run an existing image already downloaded to your machine. This is useful when working offline or you are unable to access the Docker registry.
+
+Sample usage:
+
+```bash
+npx @americanexpress/one-app-runner --root-module-name frank-lloyd-root --docker-image oneamex/one-app-dev:5.x.x --module-map-url https://example.com/cdn/module-map.json  --module ../frank-lloyd-root --offline
+```
+
+Or in `package.json`
+
+```json
+"one-amex": {
+  "runner": {
+    "modules": ["."],
+    "rootModuleName": "frank-lloyd-root",
+    "moduleMapUrl": "https://example.com/cdn/module-map.json",
+    "dockerImage": "oneamex/one-app-dev:5.x.x",
+    "offline": true
+  }
+}
+```
+
 ### envVars [Optional]
 
 Environment variables to provide to One App instance.

--- a/packages/one-app-runner/__tests__/bin/__snapshots__/one-app-runner.spec.js.snap
+++ b/packages/one-app-runner/__tests__/bin/__snapshots__/one-app-runner.spec.js.snap
@@ -25,6 +25,8 @@ Array [
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
                             one-app-dev-cdn           [boolean] [default: false]
+  --offline                 skip docker pull when the docker registry is not
+                            available / offline       [boolean] [default: false]
   --help                    Show help                                  [boolean]",
   ],
   Array [],
@@ -61,6 +63,8 @@ Array [
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
                             one-app-dev-cdn           [boolean] [default: false]
+  --offline                 skip docker pull when the docker registry is not
+                            available / offline       [boolean] [default: false]
   --help                    Show help                                  [boolean]",
   ],
   Array [],
@@ -95,6 +99,8 @@ Array [
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
                             one-app-dev-cdn           [boolean] [default: false]
+  --offline                 skip docker pull when the docker registry is not
+                            available / offline       [boolean] [default: false]
   --help                    Show help                                  [boolean]",
   ],
   Array [],
@@ -118,6 +124,7 @@ Array [
       "modulesToServe": Array [
         "/fake/path/to/fake-module",
       ],
+      "offline": true,
       "outputFile": "/fake/path/to/fake-module/one-app.log",
       "parrotMiddlewareFile": "/fake/path/to/fake-module/dev.middleware.js",
       "rootModuleName": "frank-lloyd-root",
@@ -223,6 +230,8 @@ Array [
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
                             one-app-dev-cdn           [boolean] [default: false]
+  --offline                 skip docker pull when the docker registry is not
+                            available / offline       [boolean] [default: false]
   --help                    Show help                                  [boolean]",
   ],
   Array [],
@@ -341,6 +350,8 @@ Array [
                                                                         [string]
   --use-host                Use req.headers.host instead of localhost for
                             one-app-dev-cdn           [boolean] [default: false]
+  --offline                 skip docker pull when the docker registry is not
+                            available / offline       [boolean] [default: false]
   --help                    Show help                                  [boolean]",
   ],
   Array [],

--- a/packages/one-app-runner/__tests__/bin/one-app-runner.spec.js
+++ b/packages/one-app-runner/__tests__/bin/one-app-runner.spec.js
@@ -230,6 +230,7 @@ test('all options are used if specified', () => {
     '--docker-network-to-join',
     dockerNetworkToJoin,
     '--use-host',
+    '--offline',
   ];
 
   jest.mock('../../src/startApp', () => jest.fn());

--- a/packages/one-app-runner/__tests__/src/__snapshots__/startApp.spec.js.snap
+++ b/packages/one-app-runner/__tests__/src/__snapshots__/startApp.spec.js.snap
@@ -2,6 +2,8 @@
 
 exports[`startApp Displays an error if createNetwork fails: create network calls 1`] = `[Error: Error creating network]`;
 
+exports[`startApp bypasses docker pull when the offline flag is passed 1`] = `" docker run -t -p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3005:3005 -e NODE_ENV=development    -v /path/to/module-a:/opt/module-workspace/module-a one-app:5.0.0 /bin/sh -c \\"npm run serve-module /opt/module-workspace/module-a &&   node lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  \\""`;
+
 exports[`startApp creates a docker network when the flag is provided: create network calls 1`] = `
 Array [
   Array [

--- a/packages/one-app-runner/__tests__/src/startApp.spec.js
+++ b/packages/one-app-runner/__tests__/src/startApp.spec.js
@@ -171,6 +171,16 @@ describe('startApp', () => {
     expect(mockSpawn.calls[0].command).toMatchSnapshot();
   });
 
+  it('bypasses docker pull when the offline flag is passed', () => {
+    const mockSpawn = require('mock-spawn')();
+
+    childProcess.spawn.mockImplementationOnce(mockSpawn);
+    startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], offline: true,
+    });
+    expect(mockSpawn.calls[0].command).toMatchSnapshot();
+  });
+
   it('outputs all logs from docker pull and docker run to a file if output file arg is given', () => {
     const mockSpawn = require('mock-spawn')();
     const mockStdout = 'hello world (stdout)';

--- a/packages/one-app-runner/bin/one-app-runner.js
+++ b/packages/one-app-runner/bin/one-app-runner.js
@@ -129,6 +129,11 @@ const createYargsConfig = () => {
       default: false,
       type: 'boolean',
     })
+    .option('offline', {
+      describe: 'skip docker pull when the docker registry is not available / offline',
+      default: false,
+      type: 'boolean',
+    })
     .implies({
       'parrot-middleware': 'modules',
       'dev-endpoints': 'modules',
@@ -158,6 +163,7 @@ try {
     createDockerNetwork: argv.createDockerNetwork,
     dockerNetworkToJoin: argv.dockerNetworkToJoin,
     useHost: argv.useHost,
+    offline: argv.offline,
   });
 } catch (error) {
   /* eslint-disable no-console */

--- a/packages/one-app-runner/src/startApp.js
+++ b/packages/one-app-runner/src/startApp.js
@@ -29,6 +29,7 @@ module.exports = async function startApp({
   createDockerNetwork,
   dockerNetworkToJoin,
   useHost,
+  offline,
 }) {
   const generateEnvironmentVariableArgs = (vars) => {
     const environmentVariablesWithProxyAdditions = {
@@ -112,13 +113,14 @@ module.exports = async function startApp({
 
   const generateNetworkToJoin = () => (dockerNetworkToJoin ? `--network=${dockerNetworkToJoin}` : '');
   const generateUseHostFlag = () => (useHost ? '--use-host' : '');
+  const generatePullCommand = () => (offline ? '' : `docker pull ${appDockerImage} &&`);
   const appPort = process.env.HTTP_PORT || 3000;
   const devCDNPort = process.env.HTTP_ONE_APP_DEV_CDN_PORT || 3001;
   const devProxyServerPort = process.env.HTTP_ONE_APP_DEV_PROXY_SERVER_PORT || 3002;
   const metricsPort = process.env.HTTP_METRICS_PORT || 3005;
   const ports = `-p ${appPort}:${appPort} -p ${devCDNPort}:${devCDNPort} -p ${devProxyServerPort}:${devProxyServerPort} -p ${metricsPort}:${metricsPort}`;
 
-  const command = `docker pull ${appDockerImage} && docker run -t ${ports} -e NODE_ENV=development ${generateNetworkToJoin()} ${generateEnvironmentVariableArgs(envVars)} ${generateModuleMountsArgs(modulesToServe)} ${appDockerImage} /bin/sh -c "${generateServeModuleCommands(modulesToServe)} ${generateSetMiddlewareCommand(parrotMiddlewareFile)} ${generateSetDevEndpointsCommand(devEndpointsFile)} node lib/server/index.js --root-module-name=${rootModuleName} ${generateModuleMap()} ${generateUseMocksFlag(parrotMiddlewareFile)} ${generateUseHostFlag()}"`;
+  const command = `${generatePullCommand()} docker run -t ${ports} -e NODE_ENV=development ${generateNetworkToJoin()} ${generateEnvironmentVariableArgs(envVars)} ${generateModuleMountsArgs(modulesToServe)} ${appDockerImage} /bin/sh -c "${generateServeModuleCommands(modulesToServe)} ${generateSetMiddlewareCommand(parrotMiddlewareFile)} ${generateSetDevEndpointsCommand(devEndpointsFile)} node lib/server/index.js --root-module-name=${rootModuleName} ${generateModuleMap()} ${generateUseMocksFlag(parrotMiddlewareFile)} ${generateUseHostFlag()}"`;
   const dockerProcess = spawn(command, { shell: true });
   dockerProcess.on('error', () => {
     throw new Error(


### PR DESCRIPTION
New feature:

Pass the --offline option to one-app-runner to bypass `docker pull` and work offline when the image has been downloaded already and you are offline or not able to connect to the Docker registry

fixes https://github.com/americanexpress/one-app-cli/issues/44