### PR TITLE
fix(bundler): add trailing slash to externals resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5030,6 +5030,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "postinstall": "lerna bootstrap",
     "test:lint": "eslint --ext js,jsx,snap,md .",
-    "test:unit": "NODE_ENV=production jest",
+    "test:unit": "cross-env NODE_ENV=production jest",
     "test": "npm run test:unit",
     "test:git-history": "commitlint --from origin/main --to HEAD",
     "test:lockfile": "node lockFileLint.js",
@@ -16,6 +16,7 @@
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
     "amex-jest-preset": "^6.1.0",
+    "cross-env": "^7.0.2",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.2.2",
     "eslint": "^6.8.0",

--- a/packages/one-app-bundler/__tests__/utils/__snapshots__/extendWebpackConfig.spec.js.snap
+++ b/packages/one-app-bundler/__tests__/utils/__snapshots__/extendWebpackConfig.spec.js.snap
@@ -18,9 +18,54 @@ Object {
 }
 `;
 
+exports[`extendWebpackConfig should use the correct trailing slash on windows 1`] = `
+Object {
+  "test": StringMatching /ajv\\\\\\\\\\$/,
+  "use": Array [
+    Object {
+      "loader": "@americanexpress/one-app-bundler/webpack/loaders/externals-loader",
+      "options": Object {
+        "externalName": "ajv",
+      },
+    },
+  ],
+}
+`;
+
+exports[`extendWebpackConfig should use the correct trailing slash on windows 2`] = `
+Object {
+  "test": StringMatching /lodash\\\\\\\\\\$/,
+  "use": Array [
+    Object {
+      "loader": "@americanexpress/one-app-bundler/webpack/loaders/externals-loader",
+      "options": Object {
+        "externalName": "lodash",
+      },
+    },
+  ],
+}
+`;
+
+exports[`extendWebpackConfig should use the correct trailing slash on windows 3`] = `
+Object {
+  "test": "/path/src/index",
+  "use": Array [
+    Object {
+      "loader": "@americanexpress/one-app-bundler/webpack/loaders/validate-required-externals-loader",
+      "options": Object {
+        "requiredExternals": Array [
+          "ajv",
+          "lodash",
+        ],
+      },
+    },
+  ],
+}
+`;
+
 exports[`extendWebpackConfig should use the provided requiredExternals configured 1`] = `
 Object {
-  "test": StringMatching /ajv/,
+  "test": StringMatching /ajv\\\\/\\$/,
   "use": Array [
     Object {
       "loader": "@americanexpress/one-app-bundler/webpack/loaders/externals-loader",
@@ -34,7 +79,7 @@ Object {
 
 exports[`extendWebpackConfig should use the provided requiredExternals configured 2`] = `
 Object {
-  "test": StringMatching /lodash/,
+  "test": StringMatching /lodash\\\\/\\$/,
   "use": Array [
     Object {
       "loader": "@americanexpress/one-app-bundler/webpack/loaders/externals-loader",

--- a/packages/one-app-bundler/__tests__/utils/extendWebpackConfig.spec.js
+++ b/packages/one-app-bundler/__tests__/utils/extendWebpackConfig.spec.js
@@ -52,7 +52,10 @@ describe('extendWebpackConfig', () => {
 
   jest.spyOn(process, 'cwd').mockImplementation(() => '/path');
 
+  const originalPlatform = process.platform;
+
   beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
     jest.clearAllMocks();
     originalWebpackConfig = {
       resolve: {
@@ -115,13 +118,30 @@ describe('extendWebpackConfig', () => {
 
     expect(rules).toHaveLength(originalWebpackConfig.module.rules.length + 3);
     expect(rules[rules.length - 3]).toMatchSnapshot({
-      test: expect.stringMatching(/ajv/),
+      test: expect.stringMatching(/ajv\/$/),
     });
     expect(rules[rules.length - 2]).toMatchSnapshot({
-      test: expect.stringMatching(/lodash/),
+      test: expect.stringMatching(/lodash\/$/),
     });
     expect(rules[rules.length - 1]).toMatchSnapshot();
   });
+
+  it('should use the correct trailing slash on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    getConfigOptions.mockReturnValueOnce({ requiredExternals: ['ajv', 'lodash'] });
+    const result = extendWebpackConfig(originalWebpackConfig);
+    const { rules } = result.module;
+
+    expect(rules).toHaveLength(originalWebpackConfig.module.rules.length + 3);
+    expect(rules[rules.length - 3]).toMatchSnapshot({
+      test: expect.stringMatching(/ajv\\$/),
+    });
+    expect(rules[rules.length - 2]).toMatchSnapshot({
+      test: expect.stringMatching(/lodash\\$/),
+    });
+    expect(rules[rules.length - 1]).toMatchSnapshot();
+  });
+
 
   it('should validate the one app version', () => {
     getConfigOptions.mockReturnValueOnce({ appCompatibility: '^4.41.0' });

--- a/packages/one-app-bundler/utils/extendWebpackConfig.js
+++ b/packages/one-app-bundler/utils/extendWebpackConfig.js
@@ -72,7 +72,7 @@ function extendWebpackConfig(webpackConfig, bundleTarget) {
     customWebpackConfig = merge(customWebpackConfig, {
       module: {
         rules: [...requiredExternals.map((externalName) => ({
-          test: `${resolve(externalName)}/`,
+          test: resolve(externalName),
           use: [{
             loader: '@americanexpress/one-app-bundler/webpack/loaders/externals-loader',
             options: {

--- a/packages/one-app-bundler/webpack/createResolver.js
+++ b/packages/one-app-bundler/webpack/createResolver.js
@@ -32,5 +32,7 @@ module.exports = function createResolver({ mainFields, resolveToContext = false 
     resolveToContext,
   });
 
-  return (request) => enhancedResolver.resolveSync({}, __dirname, request);
+  const trailingSlash = (process.platform === 'win32') ? '\\' : '/';
+  // if resolveToContext add a trailing slash to indicate the value is a folder rather than  a file
+  return (request) => `${enhancedResolver.resolveSync({}, __dirname, request)}${resolveToContext ? trailingSlash : ''}`;
 };


### PR DESCRIPTION
[enhance-resolve](https://github.com/webpack/enhanced-resolve) `resolveToContext` resolves to a directory not a file, however if we don't add a trailing slash to indicate the end of the absolute path, the [test](https://webpack.js.org/configuration/module/#condition) matcher from webpack module incorrectly resolves paths that start with the same name and are separated by a hyphen i.e. `iguazu` will be resolved instead of `iguazu-rpc` if the trailing slash is not present. see https://github.com/americanexpress/one-app-cli/pull/81

This PR adds the correct trailing slash depending on the platform i.e. windows/darwin to the `createResolver.js` when `resolveToContext` is true



