### PR TITLE
fix(readPkgUp): fix use packageJson from readPkgUp.sync instead of pkg

### DIFF
--- a/packages/one-app-bundler/__tests__/utils/getConfigOptions.spec.js
+++ b/packages/one-app-bundler/__tests__/utils/getConfigOptions.spec.js
@@ -26,76 +26,76 @@ describe('getConfigOptions', () => {
   });
 
   it('should handle missing one-amex config', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: {} });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: {} });
     const getConfigOptions = require('../../utils/getConfigOptions');
     expect(getConfigOptions).not.toThrow();
   });
 
   it('should handle missing bundler config', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { runner: {} } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { runner: {} } } });
     const getConfigOptions = require('../../utils/getConfigOptions');
     expect(getConfigOptions).not.toThrow();
   });
 
   it('should include app compatability', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { app: { compatibility: '^5.1.0' } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { app: { compatibility: '^5.1.0' } } } });
     const getConfigOptions = require('../../utils/getConfigOptions');
     expect(getConfigOptions()).toMatchObject({ appCompatibility: '^5.1.0' });
   });
 
   it('should default purgecss to an empty object', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: {} });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: {} });
     const getConfigOptions = require('../../utils/getConfigOptions');
     expect(getConfigOptions()).toMatchObject({ purgecss: {} });
   });
 
   it('should not override an existing purgecss config', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { purgecss: { paths: ['foo'] } } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { purgecss: { paths: ['foo'] } } } } });
     const getConfigOptions = require('../../utils/getConfigOptions');
     expect(getConfigOptions()).toMatchObject({ purgecss: { paths: ['foo'] } });
   });
 
   it('should throw when a user includes both requiredExternals and providedExternals configs', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { requiredExternals: ['a'], providedExternals: ['b'] } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { requiredExternals: ['a'], providedExternals: ['b'] } } } });
     expect(() => require('../../utils/getConfigOptions')).toThrowErrorMatchingSnapshot();
   });
 
   it('should allow a user to include requiredExternals', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { providedExternals: ['b'] } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { providedExternals: ['b'] } } } });
     expect(() => require('../../utils/getConfigOptions')).not.toThrow();
   });
 
   it('should throw when a user attempts to provide an app provided external', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { providedExternals: ['@americanexpress/one-app-ducks'] } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { providedExternals: ['@americanexpress/one-app-ducks'] } } } });
     expect(() => require('../../utils/getConfigOptions')).toThrowErrorMatchingSnapshot();
   });
 
   it('should throw when a user attempts to use an app provided external from the root module', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { requiredExternals: ['@americanexpress/one-app-router'] } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { requiredExternals: ['@americanexpress/one-app-router'] } } } });
     expect(() => require('../../utils/getConfigOptions')).toThrowErrorMatchingSnapshot();
   });
 
   it('should warn when the user provides a custom webpack config', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { webpackConfigPath: 'webpack.config.js' } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { webpackConfigPath: 'webpack.config.js' } } } });
     require('../../utils/getConfigOptions');
     expect(consoleWarnSpy).toHaveBeenCalledWith('@americanexpress/one-app-bundler: Using a custom webpack config can cause unintended side effects. Issues resulting from custom configuration will not be supported.');
   });
 
   it('should warn when the user provides a custom client webpack config', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { webpackClientConfigPath: 'webpack.client.config.js' } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { webpackClientConfigPath: 'webpack.client.config.js' } } } });
     require('../../utils/getConfigOptions');
     expect(consoleWarnSpy).toHaveBeenCalledWith('@americanexpress/one-app-bundler: Using a custom webpack config can cause unintended side effects. Issues resulting from custom configuration will not be supported.');
   });
 
   it('should warn when the user provides a custom server webpack config', () => {
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { webpackServerConfigPath: 'webpack.config.js' } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { webpackServerConfigPath: 'webpack.config.js' } } } });
     require('../../utils/getConfigOptions');
     expect(consoleWarnSpy).toHaveBeenCalledWith('@americanexpress/one-app-bundler: Using a custom webpack config can cause unintended side effects. Issues resulting from custom configuration will not be supported.');
   });
 
   it('should throw when a user attempts to use both webpackConfigPath and webpackClientConfigPath', () => {
     const errorRegex = /@americanexpress\/one-app-bundler: Modules cannot configure both webpackConfigPath and webpackClientConfigPath or webpackServerConfigPath. See README for details./;
-    readPkgUp.sync.mockReturnValueOnce({ pkg: { 'one-amex': { bundler: { webpackConfigPath: 'webpack.config.js', webpackClientConfigPath: 'webpack.config.js' } } } });
+    readPkgUp.sync.mockReturnValueOnce({ packageJson: { 'one-amex': { bundler: { webpackConfigPath: 'webpack.config.js', webpackClientConfigPath: 'webpack.config.js' } } } });
     expect(() => require('../../utils/getConfigOptions')).toThrow(errorRegex);
   });
 });

--- a/packages/one-app-bundler/__tests__/webpack/loaders/meta-data-loader.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/loaders/meta-data-loader.spec.js
@@ -23,7 +23,7 @@ jest.mock('read-pkg-up', () => ({
   sync: jest.fn(),
 }));
 
-readPkgUp.sync.mockImplementation(() => ({ pkg: { version: '1.0.0' } }));
+readPkgUp.sync.mockImplementation(() => ({ packageJson: { version: '1.0.0' } }));
 
 describe('validate-required-externals-loader', () => {
   it('should add versions for server side validation ', () => {

--- a/packages/one-app-bundler/__tests__/webpack/loaders/validate-externals-loader.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/loaders/validate-externals-loader.spec.js
@@ -23,7 +23,7 @@ jest.mock('read-pkg-up', () => ({
   sync: jest.fn(),
 }));
 
-readPkgUp.sync.mockImplementation(() => ({ pkg: require('../../../package.json') }));
+readPkgUp.sync.mockImplementation(() => ({ packageJson: require('../../../package.json') }));
 
 describe('validate-required-externals-loader', () => {
   it('should add versions for server side validation ', () => {

--- a/packages/one-app-bundler/__tests__/webpack/module/webpack.server.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/module/webpack.server.spec.js
@@ -15,7 +15,7 @@
 jest.spyOn(process, 'cwd').mockImplementation(() => __dirname.split('/__tests__')[0]);
 
 jest.mock('read-pkg-up', () => ({
-  sync: jest.fn(() => ({ pkg: { name: '@americanexpress/one-app-bundler', version: '6.8.0' } })),
+  sync: jest.fn(() => ({ packageJson: { name: '@americanexpress/one-app-bundler', version: '6.8.0' } })),
 }));
 
 const webpackConfig = require('../../../webpack/module/webpack.server');

--- a/packages/one-app-bundler/bin/postProcessOneAppBundle.js
+++ b/packages/one-app-bundler/bin/postProcessOneAppBundle.js
@@ -20,8 +20,8 @@ const { hashElement } = require('folder-hash');
 const readPkgUp = require('read-pkg-up');
 const generateIntegrityManifest = require('./generateIntegrityManifest');
 
-const { pkg, path: pkgPath } = readPkgUp.sync();
-const { version } = pkg;
+const { packageJson, path: pkgPath } = readPkgUp.sync();
+const { version } = packageJson;
 const tmpPath = path.resolve(pkgPath, '../build/app/tmp');
 
 

--- a/packages/one-app-bundler/utils/getConfigOptions.js
+++ b/packages/one-app-bundler/utils/getConfigOptions.js
@@ -49,10 +49,10 @@ function logConfigurationWarnings(options) {
   }
 }
 
-const { pkg } = readPkgUp.sync();
-const options = get(pkg, ['one-amex', 'bundler'], {});
+const { packageJson } = readPkgUp.sync();
+const options = get(packageJson, ['one-amex', 'bundler'], {});
 validateBundler(options);
-options.appCompatibility = get(pkg, ['one-amex', 'app', 'compatibility']);
+options.appCompatibility = get(packageJson, ['one-amex', 'app', 'compatibility']);
 options.purgecss = options.purgecss || {};
 validateOptions(options);
 logConfigurationWarnings(options);

--- a/packages/one-app-bundler/webpack/loaders/meta-data-loader.js
+++ b/packages/one-app-bundler/webpack/loaders/meta-data-loader.js
@@ -16,7 +16,7 @@ const readPkgUp = require('read-pkg-up');
 const { META_DATA_KEY } = require('../..');
 
 function metaDataLoader(content) {
-  const { pkg: { version } } = readPkgUp.sync();
+  const { packageJson: { version } } = readPkgUp.sync();
   const match = content.match(/export\s+default\s+(?!from)([\w\d]+)/);
 
   if (match) {

--- a/packages/one-app-bundler/webpack/loaders/validate-required-externals-loader.js
+++ b/packages/one-app-bundler/webpack/loaders/validate-required-externals-loader.js
@@ -18,10 +18,10 @@ const readPkgUp = require('read-pkg-up');
 function validateRequiredExternalsLoader(content) {
   const options = loaderUtils.getOptions(this);
   // eslint-disable-next-line global-require, import/no-dynamic-require
-  const { pkg } = readPkgUp.sync();
+  const { packageJson } = readPkgUp.sync();
 
   const requiredExternals = options.requiredExternals.map((externalName) => {
-    const version = pkg.dependencies[externalName];
+    const version = packageJson.dependencies[externalName];
     return `'${externalName}': '${version}'`;
   });
   const match = content.match(/export\s+default\s+(?!from)([\w\d]+)/);

--- a/packages/one-app-bundler/webpack/module/webpack.server.js
+++ b/packages/one-app-bundler/webpack/module/webpack.server.js
@@ -27,8 +27,8 @@ const {
 } = require('../loaders/common');
 
 const packageRoot = process.cwd();
-const { pkg } = readPkgUp.sync();
-const { version, name } = pkg;
+const { packageJson } = readPkgUp.sync();
+const { version, name } = packageJson;
 
 module.exports = extendWebpackConfig(merge(
   commonConfig,


### PR DESCRIPTION
Our tests didn't catch `pkg` not being returned by `read-pkg-up` due to mocking the return values in the tests to use `pkg`.