### PR TITLE
feat(extendWebpackConfig): added smartStrategy

### DIFF
--- a/packages/one-app-bundler/utils/extendWebpackConfig.js
+++ b/packages/one-app-bundler/utils/extendWebpackConfig.js
@@ -14,6 +14,7 @@
 
 const path = require('path');
 const merge = require('webpack-merge');
+const uniqBy = require('lodash/uniqBy');
 const getConfigOptions = require('./getConfigOptions');
 const getCliOptions = require('./getCliOptions');
 const createResolver = require('../webpack/createResolver');
@@ -119,7 +120,17 @@ function extendWebpackConfig(webpackConfig, bundleTarget) {
     });
   }
 
-  return merge(webpackConfig, customWebpackConfig);
+  return merge({
+    customizeArray(defaultConfig, customConfig, key) {
+      if (key === 'plugins') {
+        const merged = [...customConfig, ...defaultConfig];
+        const unique = uniqBy(merged, (plugin) => plugin.constructor && plugin.constructor.name);
+        return unique;
+      }
+
+      return undefined;
+    },
+  })(webpackConfig, customWebpackConfig);
 }
 
 module.exports = extendWebpackConfig;


### PR DESCRIPTION
## Motivation
This pull request adds a feature as well as solves a bug with the webpack merge. When a merge occurs on the `plugins` webpack configuration key, duplicate plugins are appended to the array instead of using the override version. Further, with the use of `merge.smartStrategy`, module rules can be properly appended into their appropriate rule given that the custom rule matches an existing rule.

```javascript
// original webpack configuration
{
  plugins: [new OneAppAwesomePlugin()],
};

// user webpack configuration
{
  plugins: [new OneAppAwesomePlugin({ withSomeAwesomeAdditions: true })],
}

// the resulting merge has two duplicates
// result:
{
  plugins: [new OneAppAwesomePlugin(), new OneAppAwesomePlugin({ withSomeAwesomeAdditions: true })],
}
```

## Examples

### Plugin merging

```javascript
// original webpack configuration
{
  plugins: [new OneAppAwesomePlugin()],
};

// user webpack configuration
{
  plugins: [new OneAppAwesomePlugin({ withSomeAwesomeAdditions: true })],
}

// result:
{
  plugins: [new OneAppAwesomePlugin({ withSomeAwesomeAdditions: true })],
}
```
### Module rules merging

```javascript
// original webpack configuration
{
  module: {
    rules: [{
      test: /\.jsx?$/,
      include: ['src', 'node_modules'],
      use: ['babel-loader'],
    }]
  }
}

// user webpack configuration
{
  module: {
    rules: [{
      test: /\.jsx?$/,
      include: ['src', 'node_modules'],
      use: ['an-awesome-loader'],
    }]
  }
}

// resulting
{
  module: {
    rules: [{
      test: /\.jsx?$/,
      include: ['src', 'node_modules'],
      use: ['babel-loader', 'an-awesome-loader'],
    }]
  }
}

```
## Alternatives

An alternative `merge.unique` was considered. However, when using this way of implementation, the function simply discarded the user overridden choice.
```javascript
const output = merge({
  customizeArray: merge.unique(
    'plugins',
    ['HolocronModulePlugin'],
    plugin => plugin.constructor && plugin.constructor.name
  )
})({
  plugins: [
    new HolocronModulePlugin('original-module')
  ]
}, {
  plugins: [
    new HolocronModulePlugin('custom-module')
  ]
});

// output
{
  plugins: [
    new HolocronModulePlugin('original-module')
  ],
}
```
`merge.strategy` was also considered and while it solved the `plugins` use case, it didn't handle `module.rules` appropriately.
```javascript
// original webpack configuration
{
  module: {
    rules: [{
      test: /\.jsx?$/,
      include: ['src', 'node_modules'],
      use: ['babel-loader'],
    }]
  },
  plugins: [new OneAppAwesomePlugin()],
};

// custom webpack configuration
{
  plugins: [new OneAppAwesomePlugin({ withSomeAwesomeAdditions: true })],
  module: {
    rules: [{
      test: /\.jsx?$/,
      include: ['src', 'node_modules'],
      use: ['an-awesome-loader'],
    }]
  },
}

// resulting webpack configuration, undesired module rules
{
  module: {
    rules: [{
      test: /\.jsx?$/,
      include: ['src', 'node_modules'],
      use: ['babel-loader'],
    }, {
      test: /\.jsx?$/,
      include: ['src', 'node_modules'],
      use: ['an-awesome-loader'],
    }],
  },
  plugins: [new OneAppAwesomePlugin({ withSomeAwesomeAdditions: true })],
}
```