### PR TITLE
chore(commit): disable body length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,5 +16,6 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'scope-case': [2, 'always', ['pascal-case', 'camel-case', 'kebab-case']],
+    'body-max-line-length': [0],
   },
 };


### PR DESCRIPTION
Disable the body length rule. For reference https://commitlint.js.org/#/reference-rules