### PR TITLE
fix(getPackageJsonConfig): module does not require one-amex key

### DIFF
--- a/packages/holocron-dev-server/__tests__/src/utils/config.spec.js
+++ b/packages/holocron-dev-server/__tests__/src/utils/config.spec.js
@@ -13,9 +13,8 @@
  */
 
 import readPkgUp from 'read-pkg-up';
-import { createConfig } from '../../../src';
 import { getContextPath } from '../../../src/utils/paths';
-import { createConfigurationContext } from '../../../src/utils/config';
+import { createConfig, createConfigurationContext } from '../../../src/utils/config';
 
 jest.mock('read-pkg-up');
 
@@ -145,6 +144,42 @@ describe('createConfig', () => {
       serverAddress: 'http://localhost:4000/',
     });
   });
+
+  it('creates a configuration when no "one-amex" key', async () => {
+    const simpleModuleMock = () => ({
+      packageJson: {
+        name: 'hmr',
+        version: '1.0.0',
+      },
+    });
+
+    readPkgUp.mockImplementationOnce(simpleModuleMock);
+    const config = await createConfig();
+    expect(config).toMatchObject({
+      clientConfig: {
+        errorReportingUrl: '/reports/error',
+      },
+      dockerImage: 'oneamex/one-app-dev:latest',
+      environmentVariables: undefined,
+      externals: [],
+      logLevel: 4,
+      moduleName: 'hmr',
+      modulePath: '/home',
+      moduleVersion: '1.0.0',
+      modules: [{
+        environmentVariables: undefined,
+        externals: [],
+        moduleName: 'hmr',
+        modulePath: '/home',
+        moduleVersion: '1.0.0',
+        providedExternals: undefined,
+        requiredExternals: undefined,
+        rootModule: true,
+        src: '/static/modules/hmr/hmr.js',
+      }],
+    });
+  });
+
   it('creates a configuration from various keys on "one-amex" field, if module is not present', async () => {
     const rootMock = () => ({
       packageJson: {

--- a/packages/holocron-dev-server/src/utils/config.js
+++ b/packages/holocron-dev-server/src/utils/config.js
@@ -23,14 +23,14 @@ export const BUNDLER_CONFIG_KEY = 'bundler';
 export const RUNNER_CONFIG_KEY = 'runner';
 export const HMR_CONFIG_KEY = 'hmr';
 
-export async function getPackageJsonConfig(modulePath = getContextPath()) {
+async function getPackageJsonConfig(modulePath = getContextPath()) {
   const {
     packageJson: {
       [ONE_AMEX_CONFIG_KEY]: {
         [BUNDLER_CONFIG_KEY]: bundler,
         [RUNNER_CONFIG_KEY]: runner,
         [HMR_CONFIG_KEY]: hmr,
-      },
+      } = {},
       name: moduleName,
       version: moduleVersion,
     },


### PR DESCRIPTION
if a locally served module did not have a `one-amex` key this would throw an error. 