### PR TITLE
fix(dev-server): load App Statics from docker img

### DIFF
--- a/packages/holocron-dev-server/__tests__/src/utils/statics.spec.js
+++ b/packages/holocron-dev-server/__tests__/src/utils/statics.spec.js
@@ -12,7 +12,7 @@
  * under the License.
  */
 
-import { execSync, spawnSync } from 'child_process';
+import { execSync, spawnSync, execFileSync } from 'child_process';
 
 import { ufs } from '../../../src/utils/virtual-file-system';
 import {
@@ -26,6 +26,7 @@ import { STATIC_DIR } from '../../../src/utils/paths';
 jest.mock('child_process', () => ({
   execSync: jest.fn(() => 'en-US'),
   spawnSync: jest.fn(() => ''),
+  execFileSync: jest.fn(() => ''),
 }));
 
 jest.mock('../../../src/utils/virtual-file-system', () => {
@@ -81,7 +82,7 @@ describe('loadOneAppStaticsFromDocker', () => {
   });
 
   it('catches any errors when loading in One App statics', () => {
-    execSync.mockImplementationOnce(() => {
+    execFileSync.mockImplementationOnce(() => {
       throw new Error('fail');
     });
     expect(() => loadOneAppStaticsFromDocker()).not.toThrow();
@@ -91,6 +92,7 @@ describe('loadOneAppStaticsFromDocker', () => {
 
 describe('loadStatics', () => {
   it('does nothing when One App statics already exists', async () => {
+    ufs.existsSync.mockImplementationOnce(() => true);
     expect(loadStatics()).toBeUndefined();
     expect(console.log).toHaveBeenCalledTimes(1);
     expect(console.info).toHaveBeenCalledTimes(1);
@@ -108,7 +110,8 @@ describe('loadStatics', () => {
     expect(console.log).toHaveBeenCalledTimes(3);
     expect(console.info).toHaveBeenCalledTimes(1);
     expect(console.error).not.toHaveBeenCalled();
-    expect(execSync).toHaveBeenCalledTimes(3);
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledTimes(3);
     expect(spawnSync).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/holocron-dev-server/src/utils/statics.js
+++ b/packages/holocron-dev-server/src/utils/statics.js
@@ -50,8 +50,8 @@ export function loadOneAppStaticsFromDocker({
 
     // TODO: spinner while loading, use spawn
     // TODO: replace stdout with meaningful feedback instead of docker output
-    execSync('docker pull', [dockerImage], { stdio: 'inherit' });
-    execSync('docker cp $(docker create', [dockerImage], `):opt/one-app/build/ ${tempDir}`, {
+    execSync(`docker pull ${dockerImage}`, { stdio: 'inherit' });
+    execSync(`docker cp $(docker create ${dockerImage}):opt/one-app/build/ ${tempDir}`, {
       stdio: 'inherit',
     });
 

--- a/packages/holocron-dev-server/src/utils/statics.js
+++ b/packages/holocron-dev-server/src/utils/statics.js
@@ -13,7 +13,7 @@
  */
 
 import path from 'path';
-import { execSync, spawnSync } from 'child_process';
+import { execSync, execFileSync, spawnSync } from 'child_process';
 
 import { ufs } from './virtual-file-system';
 import {
@@ -50,8 +50,9 @@ export function loadOneAppStaticsFromDocker({
 
     // TODO: spinner while loading, use spawn
     // TODO: replace stdout with meaningful feedback instead of docker output
-    execSync(`docker pull ${dockerImage}`, { stdio: 'inherit' });
-    execSync(`docker cp $(docker create ${dockerImage}):opt/one-app/build/ ${tempDir}`, {
+    execFileSync('docker', ['pull', dockerImage], { stdio: 'inherit' });
+    const imageId = execFileSync('docker', ['create', dockerImage]).toString().trim();
+    execFileSync('docker', ['cp', `${imageId}:opt/one-app/build/`, tempDir], {
       stdio: 'inherit',
     });
 


### PR DESCRIPTION
arguments passed to `execSync`  were in incorrect format. should be `child_process.execSync(command[, options])` https://nodejs.org/docs/latest-v12.x/api/child_process.html#child_process_child_process_execsync_command_options