### PR TITLE
feat(holocron-dev-server): add offline support

### DIFF
--- a/packages/holocron-dev-server/__tests__/src/utils/config.spec.js
+++ b/packages/holocron-dev-server/__tests__/src/utils/config.spec.js
@@ -66,6 +66,7 @@ describe('createConfig', () => {
       remoteModuleMapUrl: undefined,
       environmentVariables: undefined,
       openWhenReady: false,
+      offline: false,
       clientConfig: { errorReportingUrl: '/reports/error' },
       sourceMap: undefined,
       webpackConfigPath: undefined,

--- a/packages/holocron-dev-server/__tests__/src/utils/statics.spec.js
+++ b/packages/holocron-dev-server/__tests__/src/utils/statics.spec.js
@@ -88,6 +88,11 @@ describe('loadOneAppStaticsFromDocker', () => {
     expect(() => loadOneAppStaticsFromDocker()).not.toThrow();
     expect(console.error).toHaveBeenCalledTimes(1);
   });
+  it('loads statics in offline mode', () => {
+    const offline = true;
+    expect(() => loadOneAppStaticsFromDocker({ offline })).not.toThrow();
+    expect(console.log).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('loadStatics', () => {

--- a/packages/holocron-dev-server/src/server.js
+++ b/packages/holocron-dev-server/src/server.js
@@ -65,6 +65,7 @@ export default async function holocronDevServer({
   remoteModuleMapUrl,
   dockerImage,
   webpackConfigPath,
+  offline,
 }) {
   if (!isDevelopment()) {
     logError(
@@ -78,7 +79,7 @@ export default async function holocronDevServer({
 
   logServerStart({ rootModuleName });
 
-  await loadStatics({ dockerImage });
+  await loadStatics({ dockerImage, offline });
   await loadLanguagePacks({ modules });
 
   const { moduleMap, localModuleMap, remoteModuleMap } = await createModuleMap({

--- a/packages/holocron-dev-server/src/utils/config.js
+++ b/packages/holocron-dev-server/src/utils/config.js
@@ -51,6 +51,7 @@ export function extractRunnerOptions({
   moduleMapUrl,
   dockerImage,
   envVars,
+  offline,
 } = {}) {
   return {
     modules: modules.map((relativeModulePath) => path.resolve(getContextPath(), relativeModulePath)
@@ -59,6 +60,7 @@ export function extractRunnerOptions({
     environmentVariables: envVars,
     rootModuleName,
     dockerImage,
+    offline,
   };
 }
 
@@ -161,6 +163,7 @@ export function createConfigurationContext({
     webpackConfigPath,
     performanceBudget,
     purgecss,
+    offline = false,
   } = {
     ...extractBundlerOptions(bundler),
     ...extractRunnerOptions(runner),
@@ -189,6 +192,7 @@ export function createConfigurationContext({
     webpackConfigPath,
     performanceBudget,
     purgecss,
+    offline,
   };
 }
 

--- a/packages/holocron-dev-server/src/utils/logs/messages.js
+++ b/packages/holocron-dev-server/src/utils/logs/messages.js
@@ -265,6 +265,9 @@ export function logPullingDockerImage() {
   log(printStatics('Pulling Docker image to extract One App statics'));
 }
 
+export function logOfflineMode() {
+  log(printStatics('Working offline mode, no Docker image was pulled'));
+}
 export function logOneAppVersion(appVersion) {
   log(printStatics('Using One App version v%s'), appVersion);
 }


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**

Add offline support for holocron dev server so that a docker pull is not executed. This feature uses the existing supported options from `one-app-runner` 

## **Motivation** 
#### _Why is this change required? What issue does it resolve?_

Users don't have to pull images whenever holocron-dev-server is started if they have this flag set. The image will be pulled only once

## **Test** **Conditions**
yarn packed the packaged and installed it locally


## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [x] I have added the Apache 2.0 license header to any new files created.
