### PR TITLE
Add automerge feature for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       - "npm"
       - "dependencies"
       - "dependabot"
+    target-branch: "dependabot-changes" 
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -20,3 +21,4 @@ updates:
     labels:
       - "github-actions"
       - "dependabot"
+    target-branch: "dependabot-changes"    

--- a/.github/workflows/automated-pr.yml
+++ b/.github/workflows/automated-pr.yml
@@ -1,0 +1,19 @@
+name: Dependabot Pull Request
+on:
+  schedule:
+  - cron: "0 16 * * 4"
+jobs:
+  productionPromotion:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Keep dependabot branch upto date
+        run: |
+          git fetch origin dependabot-changes:dependabot-changes
+          git reset --hard dependabot-changes
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: dependabot-changes

--- a/.github/workflows/automated-pr.yml
+++ b/.github/workflows/automated-pr.yml
@@ -1,7 +1,7 @@
 name: Dependabot Pull Request
 on:
   schedule:
-  - cron: "0 16 * * 4"
+  - cron: "0 13 * * 1"
 jobs:
   productionPromotion:
     runs-on: ubuntu-latest

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,0 +1,16 @@
+name: auto-merge
+
+on:
+  pull_request_target:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2.3
+        with:
+          github-token: ${{ secrets.PA_TOKEN }}
+          command: "squash and merge"
+          approve: true
+          target: minor


### PR DESCRIPTION
## **Description**

Automerge of dependabot PRs to branch dependabot-changes
Adding automated PR that is raised every Monday with changes


## **Motivation** 

Automate tasks and reduce the number of PRs we have to review and still ensure the project is upto date


## **Test** **Conditions**

- auto merging  minor and patches after they pass tests e.g https://github.com/nellyk/task-list-pr-checker/pull/59 this is workflow https://github.com/nellyk/task-list-pr-checker/blob/main/.github/workflows/automerge.yml

- Automated PR is then raised with all the changes  https://github.com/nellyk/task-list-pr-checker/pull/63 and https://github.com/nellyk/redux-exercise-notes/pull/30


## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [x] I have added the Apache 2.0 license header to any new files created.
