### PR TITLE
feat(bundler): add disable legacy asset flag

### DIFF
--- a/packages/one-app-bundler/README.md
+++ b/packages/one-app-bundler/README.md
@@ -228,6 +228,20 @@ negative impact on performance_.**
 }
 ```
 
+`disableLegacy` can be added to your bundler config and set to *true* to opt out of bundling the `legacy` assets. 
+This will reduce bundle size and build times. 
+**Caution as this will remove legacy browser support from your module.**  
+
+```json
+{
+  "one-amex": {
+    "bundler": {
+      "disableLegacy": true
+    }
+  }
+}
+```
+
 #### Specify what version of One App your module is compatible with
 
 You can specify which version of One App you module is compatible with by simply adding the below configuration to your `package.json`.

--- a/packages/one-app-bundler/__tests__/bin/__snapshots__/serve-module.spec.js.snap
+++ b/packages/one-app-bundler/__tests__/bin/__snapshots__/serve-module.spec.js.snap
@@ -23,9 +23,33 @@ exports[`serve-module adds to the existing module map 1`] = `
         \\"integrity\\": \\"234\\",
         \\"url\\": \\"[one-app-dev-cdn-url]/static/modules/my-module-name/1.0.0/my-module-name.browser.js\\"
       },
-      \\"legacyBrowser\\": {
-        \\"integrity\\": \\"974\\",
-        \\"url\\": \\"[one-app-dev-cdn-url]/static/modules/my-module-name/1.0.0/my-module-name.legacy.browser.js\\"
+      \\"node\\": {
+        \\"integrity\\": \\"123\\",
+        \\"url\\": \\"[one-app-dev-cdn-url]/static/modules/my-module-name/1.0.0/my-module-name.node.js\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`serve-module adds to the existing module map without legacy 1`] = `
+"{
+  \\"key\\": \\"--- omitted for development ---\\",
+  \\"modules\\": {
+    \\"another-module\\": {
+      \\"node\\": {
+        \\"url\\": \\"https://example.com/cdn/another-module/6.7.8/another-module.node.js\\",
+        \\"integrity\\": \\"123\\"
+      },
+      \\"browser\\": {
+        \\"url\\": \\"https://example.com/cdn/another-module/6.7.8/another-module.browser.js\\",
+        \\"integrity\\": \\"234\\"
+      }
+    },
+    \\"my-module-name\\": {
+      \\"browser\\": {
+        \\"integrity\\": \\"234\\",
+        \\"url\\": \\"[one-app-dev-cdn-url]/static/modules/my-module-name/1.0.0/my-module-name.browser.js\\"
       },
       \\"node\\": {
         \\"integrity\\": \\"123\\",
@@ -44,10 +68,6 @@ exports[`serve-module creates a module map when one does not exist 1`] = `
       \\"browser\\": {
         \\"integrity\\": \\"234\\",
         \\"url\\": \\"[one-app-dev-cdn-url]/static/modules/my-module-name/3.4.2/my-module-name.browser.js\\"
-      },
-      \\"legacyBrowser\\": {
-        \\"integrity\\": \\"974\\",
-        \\"url\\": \\"[one-app-dev-cdn-url]/static/modules/my-module-name/3.4.2/my-module-name.legacy.browser.js\\"
       },
       \\"node\\": {
         \\"integrity\\": \\"123\\",

--- a/packages/one-app-bundler/__tests__/bin/bundle-module.spec.js
+++ b/packages/one-app-bundler/__tests__/bin/bundle-module.spec.js
@@ -36,6 +36,7 @@ describe('bundle-module', () => {
     localeBundler = require('@americanexpress/one-app-locale-bundler');
     clientConfig = require('../../webpack/module/webpack.client');
     serverConfig = require('../../webpack/module/webpack.server');
+    jest.mock('../../utils/getConfigOptions', () => jest.fn(() => ({ disableLegacy: false })));
   });
 
   afterEach(() => {
@@ -74,6 +75,14 @@ describe('bundle-module', () => {
     expect(webpack).toHaveBeenCalledWith(clientConfig('legacy'), 'cb(legacyBrowser, true)');
     expect(webpack.mock.calls[2][0]).not.toHaveProperty('watch');
     expect(webpack.mock.calls[2][0]).not.toHaveProperty('watchOptions');
+  });
+
+  it('should not bundle module for legacy browsers when disableLegacy is true', () => {
+    jest.mock('../../utils/getConfigOptions', () => jest.fn(() => ({ disableLegacy: true })));
+    process.argv = [];
+    require('../../bin/bundle-module');
+    expect(webpack).toHaveBeenCalledTimes(2);
+    expect(webpack).not.toHaveBeenCalledWith(clientConfig('legacy'), 'cb(legacyBrowser, true)');
   });
 
   it('should use the locale bundler\'s watch mode', () => {

--- a/packages/one-app-bundler/__tests__/bin/serve-module.spec.js
+++ b/packages/one-app-bundler/__tests__/bin/serve-module.spec.js
@@ -18,6 +18,7 @@ let fs = require('fs');
 let rimraf;
 
 jest.mock('fs');
+jest.mock('../../utils/getConfigOptions', () => jest.fn(() => ({ disableLegacy: false })));
 
 const setup = (modulePath) => {
   jest.resetModules();
@@ -61,6 +62,18 @@ describe('serve-module', () => {
     fs._.setFiles({
       '../my-module-name/package.json': JSON.stringify({ name: 'my-module-name', version: '1.0.0' }),
       '../my-module-name/bundle.integrity.manifest.json': JSON.stringify({ node: '123', browser: '234', legacyBrowser: '974' }),
+    });
+    require('../../bin/serve-module');
+    expect(fs.mkdirSync).toHaveBeenCalledTimes(2);
+    expect(fs.mkdirSync.mock.calls[0][0]).toEqual('/mocked/static/modules');
+    expect(fs.mkdirSync.mock.calls[1][0]).toEqual('/mocked/static/modules/my-module-name');
+  });
+
+  it('should create a directory for the module without legacy', () => {
+    jest.mock('../../utils/getConfigOptions', () => jest.fn(() => ({ disableLegacy: true })));
+    fs._.setFiles({
+      '../my-module-name/package.json': JSON.stringify({ name: 'my-module-name', version: '1.0.0' }),
+      '../my-module-name/bundle.integrity.manifest.json': JSON.stringify({ node: '123', browser: '234' }),
     });
     require('../../bin/serve-module');
     expect(fs.mkdirSync).toHaveBeenCalledTimes(2);
@@ -151,6 +164,31 @@ describe('serve-module', () => {
     fs._.setFiles({
       '../my-module-name/package.json': JSON.stringify({ name: 'my-module-name', version: '3.4.2' }),
       '../my-module-name/bundle.integrity.manifest.json': JSON.stringify({ node: '123', browser: '234', legacyBrowser: '974' }),
+    });
+    require('../../bin/serve-module');
+    expect(fs._.getFiles()['/mocked/static/module-map.json']).toMatchSnapshot();
+  });
+
+  it('adds to the existing module map without legacy', () => {
+    jest.mock('../../utils/getConfigOptions', () => jest.fn(() => ({ disableLegacy: true })));
+    fs._.setFiles({
+      '../my-module-name/package.json': JSON.stringify({ name: 'my-module-name', version: '1.0.0' }),
+      '/mocked/static/module-map.json': JSON.stringify({
+        key: '--- omitted for development ---',
+        modules: {
+          'another-module': {
+            node: {
+              url: 'https://example.com/cdn/another-module/6.7.8/another-module.node.js',
+              integrity: '123',
+            },
+            browser: {
+              url: 'https://example.com/cdn/another-module/6.7.8/another-module.browser.js',
+              integrity: '234',
+            },
+          },
+        },
+      }),
+      '../my-module-name/bundle.integrity.manifest.json': JSON.stringify({ node: '123', browser: '234' }),
     });
     require('../../bin/serve-module');
     expect(fs._.getFiles()['/mocked/static/module-map.json']).toMatchSnapshot();

--- a/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
@@ -17,7 +17,7 @@ const { validateWebpackConfig } = require('../../../test-utils');
 const getConfigOptions = require('../../../utils/getConfigOptions');
 const configGenerator = require('../../../webpack/module/webpack.client');
 
-jest.mock('../../../utils/getConfigOptions', () => jest.fn(() => ({ purgecss: {} })));
+jest.mock('../../../utils/getConfigOptions', () => jest.fn(() => ({ purgecss: {}, disableLegacy: false })));
 
 jest.spyOn(process, 'cwd').mockImplementation(() => __dirname.split('/__tests__')[0]);
 

--- a/packages/one-app-bundler/bin/bundle-module.js
+++ b/packages/one-app-bundler/bin/bundle-module.js
@@ -18,11 +18,13 @@ const path = require('path');
 const fs = require('fs');
 const localeBundler = require('@americanexpress/one-app-locale-bundler');
 
+const getConfigOptions = require('../utils/getConfigOptions');
 const clientConfig = require('../webpack/module/webpack.client');
 const serverConfig = require('../webpack/module/webpack.server');
 const getWebpackCallback = require('./webpackCallback');
 const { watch } = require('../utils/getCliOptions')();
 
+const configOptions = getConfigOptions();
 const modernClientConfig = clientConfig('modern');
 const legacyClientConfig = clientConfig('legacy');
 
@@ -30,4 +32,5 @@ fs.writeFileSync(path.join(process.cwd(), 'bundle.integrity.manifest.json'), JSO
 localeBundler(watch);
 webpack(serverConfig, getWebpackCallback('node', true));
 webpack(modernClientConfig, getWebpackCallback('browser', true));
-webpack(legacyClientConfig, getWebpackCallback('legacyBrowser', true));
+
+if (!configOptions.disableLegacy) webpack(legacyClientConfig, getWebpackCallback('legacyBrowser', true));

--- a/packages/one-app-bundler/bin/bundle-one-app.js
+++ b/packages/one-app-bundler/bin/bundle-one-app.js
@@ -17,13 +17,19 @@ const { promisify } = require('util');
 const webpack = promisify(require('webpack'));
 const chalk = require('chalk');
 
+const getConfigOptions = require('../utils/getConfigOptions');
 const config = require('../webpack/app/webpack.client');
 const getWebpackCallback = require('./webpackCallback');
 const postProcessOneAppBundle = require('./postProcessOneAppBundle');
 
-Promise.all([
+const configOptions = getConfigOptions();
+
+const configuredPromise = !configOptions.disableLegacy ? Promise.all([
   webpack(config('modern')).then((stats) => getWebpackCallback('browser', false)(undefined, stats)),
   webpack(config('legacy')).then((stats) => getWebpackCallback('legacyBrowser', false)(undefined, stats)),
-]).then(postProcessOneAppBundle).catch((err) => {
+]) : Promise.resolve(
+  webpack(config('modern')).then((stats) => getWebpackCallback('browser', false)(undefined, stats)));
+
+configuredPromise.then(postProcessOneAppBundle).catch((err) => {
   console.log(chalk.red(err), chalk.red(err.stack));
 });

--- a/packages/one-app-bundler/utils/getConfigOptions.js
+++ b/packages/one-app-bundler/utils/getConfigOptions.js
@@ -55,6 +55,7 @@ validateBundler(options);
 options.appCompatibility = get(packageJson, ['one-amex', 'app', 'compatibility']);
 options.purgecss = options.purgecss || {};
 options.moduleName = packageJson.name;
+options.disableLegacy = options.disableLegacy || false;
 validateOptions(options);
 logConfigurationWarnings(options);
 

--- a/packages/one-app-bundler/utils/validation/index.js
+++ b/packages/one-app-bundler/utils/validation/index.js
@@ -55,6 +55,7 @@ const optionsSchema = Joi.object({
   webpackConfigPath: webpackConfigSchema,
   webpackClientConfigPath: webpackConfigSchema,
   webpackServerConfigPath: webpackConfigSchema,
+  disableLegacy: Joi.boolean().strict(),
 });
 
 function validateSchema(schema, validationTarget) {

--- a/packages/one-app-bundler/webpack/module/webpack.client.js
+++ b/packages/one-app-bundler/webpack/module/webpack.client.js
@@ -38,6 +38,7 @@ const { version, name } = packageJson;
 
 module.exports = (babelEnv) => {
   const configOptions = getConfigOptions();
+
   return extendWebpackConfig(merge(
     commonConfig,
     {
@@ -46,8 +47,8 @@ module.exports = (babelEnv) => {
         crossOriginLoading: 'anonymous',
         path: path.join(packageRoot, 'build', version),
         publicPath: '__holocron_publicPath_placeholder__',
-        filename: `${name}.${babelEnv !== 'modern' ? 'legacy.browser' : 'browser'}.js`,
-        chunkFilename: `[name].chunk.${babelEnv !== 'modern' ? 'legacy.browser' : 'browser'}.js`,
+        filename: `${name}.${babelEnv !== 'modern' && !configOptions.disableLegacy ? 'legacy.browser' : 'browser'}.js`,
+        chunkFilename: `[name].chunk.${babelEnv !== 'modern' && !configOptions.disableLegacy ? 'legacy.browser' : 'browser'}.js`,
         library: 'holocronModule',
         libraryExport: 'default',
       },


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_
Have the ability to pass a flag to the build command which will skip the legacy asset generation. Output will be: `.node`, `.browser`, `.manifest`.
An invalid flag or no flag will generate the entire asset bundle with `.node`, `.browser`, `.legacyBrowser`, `.manifest`.

#### _This project only accepts pull requests related to open issues._
#### _If suggesting a new feature or change, please discuss it in an issue first._
#380 

## **Motivation** 
#### _Why is this change required? What issue does it resolve?_

Currently, there is not a way to opt out of generating the legacy asset when building with one app bundler.
Build time for prod, watch:build and development is slower when generating the entire build collection produced today.
Including the legacy asset increases our bundle size limit because it includes the legacy bundle which does not always need to be supported for every project which can cause your module to exceed the bundle size limit even when that legacy bundle is never used.

## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 

This change has no affect on the current code or behavior. There will only be a difference if the flag has a value of _true_.

**How to test:**

1. Navigate to `packages/one-app-bundler`.
2. Run `npm pack`.
3. Install that package in your module.
4. Delete all the `.webpack-*` and `.manifest` files.
5. Update your package.json bundler config to use: `"bundler": { "disableLegacy": true }`
6. Run npm build.
7. Time the build times for production, development.
8. Repeat the steps, but without `"bundler": { "disableLegacy": false }`
9. Compare build times.

**Stats generated from one of our modules.**
Production Build Time: 11 seconds modern asset, 16-17 seconds with legacy asset.
Development Build Time: 16 seconds modern asset, 23-25 seconds with legacy asset.
watch:build Time: ~3-4 second reduction.

## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
