### PR TITLE
fix(asset-warning): disable for legacy

### DIFF
--- a/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
@@ -47,6 +47,14 @@ describe('webpack/module.client', () => {
     });
   });
 
+  it('does not warn for perf budget violations for legacy', () => {
+    const webpackConfig = configGenerator('legacy');
+    expect(webpackConfig.performance).toMatchObject({
+      maxAssetSize: 250e3,
+      hints: false,
+    });
+  });
+
   it('should error for perf budget violations in production', () => {
     process.env.NODE_ENV = 'production';
     const webpackConfig = configGenerator();

--- a/packages/one-app-bundler/webpack/module/webpack.client.js
+++ b/packages/one-app-bundler/webpack/module/webpack.client.js
@@ -60,7 +60,7 @@ module.exports = (babelEnv) => {
       performance: {
         maxAssetSize: configOptions.performanceBudget || 250e3,
         maxEntrypointSize: configOptions.performanceBudget || 250e3,
-        hints: process.env.NODE_ENV === 'development' ? 'warning' : 'error',
+        hints: babelEnv !== 'legacy' && (process.env.NODE_ENV === 'development' ? 'warning' : 'error'),
       },
       module: {
         rules: [


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_
this disables asset size warnings for legacy bundles, which are often significantly larger than a modern bundle

#### _This project only accepts pull requests related to open issues._
#### _If suggesting a new feature or change, please discuss it in an issue first._


## **Motivation** 
#### _Why is this change required? What issue does it resolve?_
reduce noise. 

## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 

Tested against locally created module ensured that warning was still present for modern bundle but not for legacy. 


## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
