### PR TITLE
chore(publish): revert to manual version step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: main
           token: ${{ secrets.PA_TOKEN }}
       - name: Node Install
         uses: actions/setup-node@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,15 @@ This project adheres to the American Express [Code of Conduct](./CODE_OF_CONDUCT
 
 ### Creating a `one-app-cli` new release
 
-1. Run the [manually publish](https://github.com/americanexpress/one-app-cli/actions/workflows/publish.yml) github action workflow.
+1. Create, checkout and push a new release branch
+2. Run `yarn lerna:version` locally from your release branch. This will push your release changes(changelog and tags) to the branch on github.
+3. Ensure that correctly formatted tags have been created for each package being versioned. Tag needs to be in the format of `@americanexpress/[package-name]@x.x.x` for example`@americanexpress/one-app-bundler@6.0.0`. This can impact future releases.
+4. Create a pull request from your branch to the `main` branch with your changes.
+5. When merging try to ensure that commit does not get squashed as this will cause the tags be against missing commits.
+6. Once merged run the [manually publish](https://github.com/americanexpress/one-app-cli/actions/workflows/publish.yml) github action workflow.
 
-One App Cli is currently not setup for pre-releases
-https://github.com/lerna/lerna/tree/main/commands/publish#--canary
+One App Cli is currently not setup for pre-releases.
+In theory, if one is required, using [--conventional-prerelease](https://github.com/lerna/lerna/tree/main/commands/version#--conventional-prerelease) in step two should work. For example: `yarn lerna:version --conventional-prerelease`
 
 ## Submitting a new feature
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "test:git-history": "commitlint --from origin/main --to HEAD",
     "posttest": "yarn test:lint && yarn test:git-history && yarn test:lockfile",
     "test:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts registry.yarnpkg.com --validate-https",
-    "lerna:version": "lerna version",
-    "lerna:publish": "lerna publish --yes"
+    "lerna:version": "lerna version --include-merged-tags",
+    "lerna:publish": "lerna publish --from-git --yes"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_

After much trial an error I have decided to revert to the method of locally versioning. This has an increased change that the tags are left pointing to commits that do not end up on the main branch. The reason for this is due to the way github enforces status checks on branch protection. I have been unable to figure out how status checks can rerun as part of `lerna version`. 
https://github.com/americanexpress/one-app-cli/runs/5278800963?check_suite_focus=true

It possible that the following steps  in an action could get around this restriction but i am running out of time to verify

* run `lerna version --no-push`
* open a pr from a new branch
* wait for status checks to succeed on the branch
* on success push to main
* finally run `lerna publish`

#### _This project only accepts pull requests related to open issues._
#### _If suggesting a new feature or change, please discuss it in an issue first._


## **Motivation** 
#### _Why is this change required? What issue does it resolve?_


## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 


## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
