### PR TITLE
fix(lazy-loading): fixed webpack filename clashing issue

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 one-app-team-review-requested:
-  - '*'
+  - '**/*'
 
 # Add 'eslint-plugin-one-app' label to any file changes
 # in the eslint-plugin-one-app package

--- a/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
@@ -14,13 +14,13 @@
 
 /* eslint-disable global-require */
 const { sync } = require('read-pkg-up');
+const path = require('path');
 const { validateWebpackConfig } = require('../../../test-utils');
 const getConfigOptions = require('../../../utils/getConfigOptions');
 const configGenerator = require('../../../webpack/module/webpack.client');
 
 jest.mock('../../../utils/getConfigOptions', () => jest.fn(() => ({ purgecss: {} })));
-jest.spyOn(process, 'cwd').mockImplementation(() => __dirname.split('/__tests__')[0]);
-jest.spyOn(process, 'cwd').mockImplementation(() => __dirname.split('/__tests__')[0]);
+jest.spyOn(process, 'cwd').mockImplementation(() => __dirname.split(`${path.sep}__tests__`)[0]);
 
 describe('webpack/module.client', () => {
   let originalNodeEnv;

--- a/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/module/webpack.client.spec.js
@@ -13,12 +13,13 @@
  */
 
 /* eslint-disable global-require */
+const { sync } = require('read-pkg-up');
 const { validateWebpackConfig } = require('../../../test-utils');
 const getConfigOptions = require('../../../utils/getConfigOptions');
 const configGenerator = require('../../../webpack/module/webpack.client');
 
 jest.mock('../../../utils/getConfigOptions', () => jest.fn(() => ({ purgecss: {} })));
-
+jest.spyOn(process, 'cwd').mockImplementation(() => __dirname.split('/__tests__')[0]);
 jest.spyOn(process, 'cwd').mockImplementation(() => __dirname.split('/__tests__')[0]);
 
 describe('webpack/module.client', () => {
@@ -79,5 +80,11 @@ describe('webpack/module.client', () => {
     const webpackConfig = configGenerator();
     expect(webpackConfig).toHaveProperty('plugins', expect.any(Array));
     expect(webpackConfig.plugins).toContainEqual({ definitions: { 'global.BROWSER': 'true' } });
+  });
+
+  it('should append holocronModule with name', () => {
+    const { packageJson: { name } } = sync();
+    const webpackConfig = configGenerator();
+    expect(webpackConfig.output.library).toBe(`holocronModule_${name.replace(/-/g, '_')}`);
   });
 });

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -55,7 +55,7 @@
     "file-loader": "^6.0.0",
     "folder-hash": "^3.3.0",
     "glob": "^7.1.3",
-    "holocron-module-register-webpack-plugin": "^1.2.0",
+    "holocron-module-register-webpack-plugin": "^1.2.2",
     "html-webpack-plugin": "^3.2.0",
     "joi": "^17.1.1",
     "loader-utils": "^1.2.3",

--- a/packages/one-app-bundler/webpack/module/webpack.client.js
+++ b/packages/one-app-bundler/webpack/module/webpack.client.js
@@ -36,6 +36,7 @@ const packageRoot = process.cwd();
 const { packageJson } = readPkgUp.sync();
 const { version, name } = packageJson;
 
+const holocronModuleName = `holocronModule_${name.replace(/-/g, '_')}`;
 module.exports = (babelEnv) => {
   const configOptions = getConfigOptions();
   return extendWebpackConfig(merge(
@@ -48,7 +49,7 @@ module.exports = (babelEnv) => {
         publicPath: '__holocron_publicPath_placeholder__',
         filename: `${name}.${babelEnv !== 'modern' ? 'legacy.browser' : 'browser'}.js`,
         chunkFilename: `[name].chunk.${babelEnv !== 'modern' ? 'legacy.browser' : 'browser'}.js`,
-        library: 'holocronModule',
+        library: holocronModuleName,
         libraryExport: 'default',
       },
       resolve: {
@@ -81,7 +82,7 @@ module.exports = (babelEnv) => {
         ],
       },
       plugins: [
-        new HolocronModuleRegisterPlugin(name),
+        new HolocronModuleRegisterPlugin(name, holocronModuleName),
         new webpack.DefinePlugin({
           'global.BROWSER': JSON.stringify(true),
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7296,10 +7296,10 @@ hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-
   dependencies:
     react-is "^16.7.0"
 
-holocron-module-register-webpack-plugin@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/holocron-module-register-webpack-plugin/-/holocron-module-register-webpack-plugin-1.2.0.tgz#92d05b7de08879916317875035eb636685b1ca4e"
-  integrity sha512-RvJxN2PLiCXmLEdg79ubEtDGOVM9y6f1JD+Z7feGBBcBfsRdvXg/PF/WIfE3amXCfdOl7HFt9cPb8qSkXodo6A==
+holocron-module-register-webpack-plugin@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/holocron-module-register-webpack-plugin/-/holocron-module-register-webpack-plugin-1.2.2.tgz#57c9c6eb0f5aa6bff312e627b6526e799163a49d"
+  integrity sha512-yHa9nQ4j3V5ckILcfpsG9HBgP9OTuUs9hRmj68okMQ5K4PHCqRLTYMhsWs61Mcf451rlYk0Yht6Q6JanYeriuw==
   dependencies:
     webpack "^4.29.5"
     webpack-sources "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9569,9 +9569,9 @@ minimist-options@4.1.0:
     kind-of "^6.0.3"
 
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_
Library name is changed in `webpack.client.js` to fix issue of web-pack filename clashing during lazy loading.

#### _This project only accepts pull requests related to open issues._
#### _If suggesting a new feature or change, please discuss it in an issue first._


## **Motivation** 
#### _Why is this change required? What issue does it resolve?_
To fix lazy loading issue caused by web-pack filename clash.

## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 


## **Types of changes**
#### Check boxes that apply:
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
