### PR TITLE
chore(release): revert v0.15.0 and v0.1.3

### DIFF
--- a/packages/holocron-dev-server/CHANGELOG.md
+++ b/packages/holocron-dev-server/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.3](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/holocron-dev-server@0.1.2...@americanexpress/holocron-dev-server@0.1.3) (2022-04-27)
-
-
-### Bug Fixes
-
-* **lang-pack:** path sep Issue-436 ([#445](https://github.com/americanexpress/one-app-cli/issues/445)) ([67371a9](https://github.com/americanexpress/one-app-cli/commit/67371a94c433bcfc5ebbdccbac0fb042f73872d7))
-
-
-
-
-
 ## [0.1.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/holocron-dev-server@0.1.0...@americanexpress/holocron-dev-server@0.1.2) (2022-01-18)
 
 

--- a/packages/holocron-dev-server/package.json
+++ b/packages/holocron-dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/holocron-dev-server",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "A micro-frontend dev server for Holocron Modules",
   "license": "Apache-2.0",
   "keywords": [
@@ -38,7 +38,7 @@
   "module": "src/index.js",
   "dependencies": {
     "@americanexpress/fetch-enhancers": "^1.0.3",
-    "@americanexpress/one-app-bundler": "^6.15.0",
+    "@americanexpress/one-app-bundler": "^6.14.2",
     "@americanexpress/one-app-ducks": "^4.1.1",
     "@americanexpress/one-app-router": "^1.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-beta.1",

--- a/packages/one-app-bundler/CHANGELOG.md
+++ b/packages/one-app-bundler/CHANGELOG.md
@@ -3,23 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [6.15.0](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.14.2...@americanexpress/one-app-bundler@6.15.0) (2022-04-27)
-
-
-### Bug Fixes
-
-* **lazy-loading:** fixed webpack filename clashing issue ([#446](https://github.com/americanexpress/one-app-cli/issues/446)) ([240a648](https://github.com/americanexpress/one-app-cli/commit/240a6484f0ddcbdd647943ec698a0d54b41d2838))
-* **update-holocron:** updated holocron to 1.2.3 ([#450](https://github.com/americanexpress/one-app-cli/issues/450)) ([553065b](https://github.com/americanexpress/one-app-cli/commit/553065b0447dd5f06328c37bc0879cac54d85d23))
-
-
-### Features
-
-* **bundler-parser:** @babel/eslint-parser ([#439](https://github.com/americanexpress/one-app-cli/issues/439)) ([cf6cec8](https://github.com/americanexpress/one-app-cli/commit/cf6cec8fa4eacf70cf26f521c16b0669a96f8559))
-
-
-
-
-
 ## [6.14.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.14.0...@americanexpress/one-app-bundler@6.14.2) (2022-01-18)
 
 

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-bundler",
-  "version": "6.15.0",
+  "version": "6.14.2",
   "description": "A command line interface(CLI) tool for bundling One App and its modules.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Reverts americanexpress/one-app-cli#455

No tags were created. Creating new PR with tags.