### PR TITLE
chore(release): publish packages

### DIFF
--- a/packages/eslint-plugin-one-app/CHANGELOG.md
+++ b/packages/eslint-plugin-one-app/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [6.13.0](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/eslint-plugin-one-app@6.12.0...@americanexpress/eslint-plugin-one-app@6.13.0) (2022-08-11)
+
+
+### Features
+
+* **holocron-dev-server:** add holocron dev server ([bf5d231](https://github.com/americanexpress/one-app-cli/commit/bf5d231c2c50c8ca2db4152e13d13eee0c149589))
+
+
+
+
+
 # 6.12.0 (2021-09-13)
 
 
@@ -58,6 +74,3 @@
 ### Features
 
 * **all:** initial oss release ([696609c](https://github.com/americanexpress/one-app-cli/commit/696609c702b128ba0339064173ac328ce8c00766))
-
-
-

--- a/packages/eslint-plugin-one-app/package.json
+++ b/packages/eslint-plugin-one-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/eslint-plugin-one-app",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "This package has Eslint configurations used by one-app.",
   "main": "index.js",
   "jest": {

--- a/packages/generator-one-app-module/CHANGELOG.md
+++ b/packages/generator-one-app-module/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.12.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/generator-one-app-module@6.12.0...@americanexpress/generator-one-app-module@6.12.2) (2022-08-11)
+
+
+### Bug Fixes
+
+* **bundler:** default hashing method doesnt work in node 18 ([#465](https://github.com/americanexpress/one-app-cli/issues/465)) ([9441a18](https://github.com/americanexpress/one-app-cli/commit/9441a1817719fc7183967cdcee52d7ce0d7a39a0))
+* **deps:** update one-app-ducks to 4.3.1 ([#230](https://github.com/americanexpress/one-app-cli/issues/230)) ([c466a3e](https://github.com/americanexpress/one-app-cli/commit/c466a3ee1e526045570835ec2e1fe97e56bde926))
+
+
+
+
+
 ## [6.12.1](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/generator-one-app-module@6.12.0...@americanexpress/generator-one-app-module@6.12.1) (2021-11-16)
 
 

--- a/packages/generator-one-app-module/package.json
+++ b/packages/generator-one-app-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/generator-one-app-module",
-  "version": "6.12.1",
+  "version": "6.12.2",
   "description": "generator for One App Modules",
   "license": "Apache-2.0",
   "contributors": [

--- a/packages/holocron-dev-server/CHANGELOG.md
+++ b/packages/holocron-dev-server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.4](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/holocron-dev-server@0.1.3...@americanexpress/holocron-dev-server@0.1.4) (2022-08-11)
+
+**Note:** Version bump only for package @americanexpress/holocron-dev-server
+
+
+
+
+
 ## [0.1.3](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/holocron-dev-server@0.1.2...@americanexpress/holocron-dev-server@0.1.3) (2022-04-27)
 
 

--- a/packages/holocron-dev-server/package.json
+++ b/packages/holocron-dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/holocron-dev-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A micro-frontend dev server for Holocron Modules",
   "license": "Apache-2.0",
   "keywords": [
@@ -38,7 +38,7 @@
   "module": "src/index.js",
   "dependencies": {
     "@americanexpress/fetch-enhancers": "^1.0.3",
-    "@americanexpress/one-app-bundler": "^6.15.0",
+    "@americanexpress/one-app-bundler": "^6.15.1",
     "@americanexpress/one-app-ducks": "^4.1.1",
     "@americanexpress/one-app-router": "^1.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-beta.1",

--- a/packages/one-app-bundler/CHANGELOG.md
+++ b/packages/one-app-bundler/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.15.1](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.15.0...@americanexpress/one-app-bundler@6.15.1) (2022-08-11)
+
+
+### Bug Fixes
+
+* **bundler:** default hashing method doesnt work in node 18 ([#465](https://github.com/americanexpress/one-app-cli/issues/465)) ([9441a18](https://github.com/americanexpress/one-app-cli/commit/9441a1817719fc7183967cdcee52d7ce0d7a39a0))
+
+
+
+
+
 # [6.15.0](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.14.2...@americanexpress/one-app-bundler@6.15.0) (2022-04-27)
 
 

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-bundler",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "A command line interface(CLI) tool for bundling One App and its modules.",
   "main": "index.js",
   "bin": {
@@ -38,8 +38,8 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@americanexpress/eslint-plugin-one-app": "^6.12.0",
-    "@americanexpress/one-app-locale-bundler": "^6.5.2",
+    "@americanexpress/eslint-plugin-one-app": "^6.13.0",
+    "@americanexpress/one-app-locale-bundler": "^6.5.3",
     "@americanexpress/purgecss-loader": "^2.0.0",
     "@babel/core": "^7.17.5",
     "@babel/eslint-parser": "^7.17.0",

--- a/packages/one-app-locale-bundler/CHANGELOG.md
+++ b/packages/one-app-locale-bundler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.5.3](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-locale-bundler@6.5.2...@americanexpress/one-app-locale-bundler@6.5.3) (2022-08-11)
+
+**Note:** Version bump only for package @americanexpress/one-app-locale-bundler
+
+
+
+
+
 ## [6.5.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-locale-bundler@6.12.0...@americanexpress/one-app-locale-bundler@6.5.2) (2022-01-18)
 
 **Note:** Version bump only for package @americanexpress/one-app-locale-bundler

--- a/packages/one-app-locale-bundler/package.json
+++ b/packages/one-app-locale-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-locale-bundler",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "description": "A command line interface(CLI) tool for bundling the locale files.",
   "bin": {
     "bundle-module-locale": "./bin/bundle-module-locale.js"

--- a/packages/one-app-runner/CHANGELOG.md
+++ b/packages/one-app-runner/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.14.0](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.12.0...@americanexpress/one-app-runner@6.14.0) (2022-08-11)
+
+
+### Features
+
+* **one-app-bundler:** add node 16 support ([#412](https://github.com/americanexpress/one-app-cli/issues/412)) ([fe8db76](https://github.com/americanexpress/one-app-cli/commit/fe8db7619a0f7789d095c827e3ddce36fb758ea1))
+* **one-app-runner:** add use-debug flag and function ([#460](https://github.com/americanexpress/one-app-cli/issues/460)) ([13057b3](https://github.com/americanexpress/one-app-cli/commit/13057b3a4ad5d42697642ae3797d3c1fcac11162))
+* **uuuid:** update uuid from 3.x to 8.x ([#220](https://github.com/americanexpress/one-app-cli/issues/220)) ([34ca7d7](https://github.com/americanexpress/one-app-cli/commit/34ca7d7688e7e9655c2eb77576993e472b6823cb))
+
+
+
+
+
 # [6.13.0](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.12.0...@americanexpress/one-app-runner@6.13.0) (2021-11-16)
 
 

--- a/packages/one-app-runner/package.json
+++ b/packages/one-app-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-runner",
-  "version": "6.13.0",
+  "version": "6.14.0",
   "description": "CLI for running One App locally",
   "license": "Apache-2.0",
   "contributors": [


### PR DESCRIPTION
 - @americanexpress/eslint-plugin-one-app@6.13.0
 - @americanexpress/generator-one-app-module@6.12.2
 - @americanexpress/holocron-dev-server@0.1.4
 - @americanexpress/one-app-bundler@6.15.1
 - @americanexpress/one-app-locale-bundler@6.5.3
 - @americanexpress/one-app-runner@6.14.0

#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_

`yarn lerna:version`

Changes:
 - @americanexpress/eslint-plugin-one-app: 6.12.0 => 6.13.0
 - @americanexpress/generator-one-app-module: 6.12.1 => 6.12.2
 - @americanexpress/holocron-dev-server: 0.1.3 => 0.1.4
 - @americanexpress/one-app-bundler: 6.15.0 => 6.15.1
 - @americanexpress/one-app-locale-bundler: 6.5.2 => 6.5.3
 - @americanexpress/one-app-runner: 6.13.0 => 6.14.0

