### PR TITLE
fix(hash): use OpenSSL supported hash for webpack

### DIFF
--- a/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
@@ -15,6 +15,7 @@
 /* eslint-disable global-require --
 we need to require generated files to validate their content */
 
+const crypto = require('crypto');
 const { validateWebpackConfig } = require('../../../test-utils');
 const configGenerator = require('../../../webpack/app/webpack.client');
 const getConfigOptions = require('../../../utils/getConfigOptions');
@@ -46,6 +47,21 @@ describe('webpack/app', () => {
 
   afterAll(() => {
     process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('should replace md4 with sha256 as default hash algo', () => {
+    const mockHash = jest.fn();
+    crypto.createHash = mockHash;
+    require('../../../webpack/app/webpack.client');
+    crypto.createHash('md4');
+    expect(mockHash).toHaveBeenCalledWith('sha256');
+  });
+  it('should keep hash if different than md4', () => {
+    const mockHash = jest.fn();
+    crypto.createHash = mockHash;
+    require('../../../webpack/app/webpack.client');
+    crypto.createHash('sha512');
+    expect(mockHash).toHaveBeenCalledWith('sha512');
   });
 
   it('should export valid webpack config', () => {

--- a/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
@@ -35,7 +35,7 @@ describe('webpack/app', () => {
   let originalNodeEnv;
 
   jest.spyOn(process, 'cwd').mockImplementation(() => '/');
-  const originalCreateHash = crypto.createHash;
+  const createHashSpy = jest.spyOn(crypto, 'createHash');
 
   beforeAll(() => {
     originalNodeEnv = process.env.NODE_ENV;
@@ -48,22 +48,17 @@ describe('webpack/app', () => {
 
   afterAll(() => {
     process.env.NODE_ENV = originalNodeEnv;
-    crypto.createHash = originalCreateHash;
   });
 
   it('should replace md4 with sha256 as default hash algo', () => {
-    const mockHash = jest.fn();
-    crypto.createHash = mockHash;
     require('../../../webpack/app/webpack.client');
     crypto.createHash('md4');
-    expect(mockHash).toHaveBeenCalledWith('sha256');
+    expect(createHashSpy).toHaveBeenCalledWith('sha256');
   });
   it('should keep hash if different than md4', () => {
-    const mockHash = jest.fn();
-    crypto.createHash = mockHash;
     require('../../../webpack/app/webpack.client');
     crypto.createHash('sha512');
-    expect(mockHash).toHaveBeenCalledWith('sha512');
+    expect(createHashSpy).toHaveBeenCalledWith('sha512');
   });
 
   it('should export valid webpack config', () => {

--- a/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
@@ -35,6 +35,7 @@ describe('webpack/app', () => {
   let originalNodeEnv;
 
   jest.spyOn(process, 'cwd').mockImplementation(() => '/');
+  const originalCreateHash = crypto.createHash;
 
   beforeAll(() => {
     originalNodeEnv = process.env.NODE_ENV;
@@ -47,6 +48,7 @@ describe('webpack/app', () => {
 
   afterAll(() => {
     process.env.NODE_ENV = originalNodeEnv;
+    crypto.createHash = originalCreateHash;
   });
 
   it('should replace md4 with sha256 as default hash algo', () => {

--- a/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/app/webpack.client.spec.js
@@ -46,6 +46,8 @@ describe('webpack/app', () => {
     jest.resetModules();
   });
 
+  afterEach(() => createHashSpy.mockClear());
+
   afterAll(() => {
     process.env.NODE_ENV = originalNodeEnv;
   });

--- a/packages/one-app-bundler/webpack/app/webpack.client.js
+++ b/packages/one-app-bundler/webpack/app/webpack.client.js
@@ -15,6 +15,7 @@
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 const path = require('path');
+const crypto = require('crypto');
 const TerserPlugin = require('terser-webpack-plugin');
 const coreJsCompat = require('core-js-compat');
 const coreJsEntries = require('core-js-compat/entries');
@@ -54,6 +55,11 @@ const getCoreJsModulePaths = (targets) => {
     .filter((entry) => coreJsEntries[entry]
       .filter((moduleName) => moduleNames.includes(moduleName)).length);
 };
+
+// Monkey Patch for unsupported hash algo. Needed to support Node >=17.
+// https://github.com/webpack/webpack/issues/13572#issuecomment-923736472
+const originalCreateHash = crypto.createHash;
+crypto.createHash = (algo) => originalCreateHash(algo === 'md4' ? 'sha256' : algo);
 
 module.exports = (babelEnv) => merge(
   common,


### PR DESCRIPTION
This is needed for Node 17 and greater, otherwise the --openssl-legacy-provider flag is required.

## **Description**
#### _Describe your changes in detail_
Node.js v17 included OpenSSL 3.0 support, which removed support for certain crypto algorithms like `md4`. `md4` is the default for Webpack 4. This change introduces a monkey patch to use sha256 instead. 
https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#openssl-30


