### PR TITLE
fix(indexloader): regex was failing on windows machines

### DIFF
--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader.spec.js
@@ -85,7 +85,7 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
 
       expect(lifeCycleHooks.onLoad.length).toBe(1);
       // eslint-disable-next-line prefer-regex-literals -- needs to match exactly
-      expect(lifeCycleHooks.onLoad[0].config).toEqual({ filter: new RegExp('[\\/]axp-mock-module-name[\\/]src[\\/]index') });
+      expect(lifeCycleHooks.onLoad[0].config).toEqual({ filter: new RegExp('[\\/]modules[\\/]src[\\/]index') });
     });
   });
 

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader.spec.js
@@ -84,7 +84,8 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
       const lifeCycleHooks = runSetupAndGetLifeHooks(plugin);
 
       expect(lifeCycleHooks.onLoad.length).toBe(1);
-      expect(lifeCycleHooks.onLoad[0].config).toEqual({ filter: /mock\/path\/to\/modules\/src\/index/ });
+      // eslint-disable-next-line prefer-regex-literals -- needs to match exactly
+      expect(lifeCycleHooks.onLoad[0].config).toEqual({ filter: new RegExp('[\\/]axp-mock-module-name[\\/]src[\\/]index') });
     });
   });
 

--- a/packages/one-app-dev-bundler/esbuild/plugins/one-app-index-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/one-app-index-loader.js
@@ -14,7 +14,6 @@
  * permissions and limitations under the License.
  */
 
-import path from 'path';
 import fs from 'fs';
 
 import { readPackageUpSync } from 'read-pkg-up';
@@ -33,7 +32,7 @@ import DevLiveReloaderInjector from './one-app-index-loader-injectors/dev-live-r
 const oneAppIndexLoader = (options) => ({
   name: 'oneAppIndexLoader',
   setup(build) {
-    const { packageJson, path: packageJsonPath } = readPackageUpSync();
+    const { packageJson } = readPackageUpSync();
     const injectorOptions = {
       packageJson,
       ...options,
@@ -47,9 +46,8 @@ const oneAppIndexLoader = (options) => ({
       new DevLiveReloaderInjector(injectorOptions),
     ];
 
-    const packageRoot = packageJsonPath.replace('package.json', '');
-
-    const filterRegex = new RegExp(path.join(packageRoot, 'src', 'index'));
+    const { name } = packageJson;
+    const filterRegex = new RegExp(`[\\/]${name}[\\/]src[\\/]index`);
 
     build.onLoad({ filter: filterRegex }, async (args) => {
       const initialContent = await fs.promises.readFile(args.path, 'utf8');

--- a/packages/one-app-dev-bundler/esbuild/plugins/one-app-index-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/one-app-index-loader.js
@@ -14,6 +14,7 @@
  * permissions and limitations under the License.
  */
 
+import path from 'path';
 import fs from 'fs';
 
 import { readPackageUpSync } from 'read-pkg-up';
@@ -32,7 +33,7 @@ import DevLiveReloaderInjector from './one-app-index-loader-injectors/dev-live-r
 const oneAppIndexLoader = (options) => ({
   name: 'oneAppIndexLoader',
   setup(build) {
-    const { packageJson } = readPackageUpSync();
+    const { packageJson, path: packageJsonPath } = readPackageUpSync();
     const injectorOptions = {
       packageJson,
       ...options,
@@ -46,8 +47,9 @@ const oneAppIndexLoader = (options) => ({
       new DevLiveReloaderInjector(injectorOptions),
     ];
 
-    const { name } = packageJson;
-    const filterRegex = new RegExp(`[\\/]${name}[\\/]src[\\/]index`);
+    const packageRoot = packageJsonPath.replace(`${path.sep}package.json`, '');
+    const folderName = packageRoot.split(path.sep).pop();
+    const filterRegex = new RegExp(`[\\/]${folderName}[\\/]src[\\/]index`);
 
     build.onLoad({ filter: filterRegex }, async (args) => {
       const initialContent = await fs.promises.readFile(args.path, 'utf8');


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_
The index loader was using the full path as the regex matcher for the esbuild filter. 

On windows machines, the regex was failing because of the path separator on Windows (`\` backslash).

This makes the regex more generic to support both windows and mac.
![image](https://user-images.githubusercontent.com/7441013/219397756-5f6b5ca4-cfbd-4881-bbeb-1b2cd30f55bc.png)

#### _This project only accepts pull requests related to open issues._
#### _If suggesting a new feature or change, please discuss it in an issue first._


## **Motivation** 
#### _Why is this change required? What issue does it resolve?_
dev bundler was broken on windows

## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 


## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
