### PR TITLE
chore(release): publish packages

### DIFF
--- a/packages/eslint-plugin-one-app/CHANGELOG.md
+++ b/packages/eslint-plugin-one-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.13.3](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/eslint-plugin-one-app@6.13.0...@americanexpress/eslint-plugin-one-app@6.13.3) (2023-02-16)
+
+**Note:** Version bump only for package @americanexpress/eslint-plugin-one-app
+
+
+
+
+
 ## [6.13.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/eslint-plugin-one-app@6.13.0...@americanexpress/eslint-plugin-one-app@6.13.2) (2022-11-16)
 
 **Note:** Version bump only for package @americanexpress/eslint-plugin-one-app

--- a/packages/eslint-plugin-one-app/package.json
+++ b/packages/eslint-plugin-one-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/eslint-plugin-one-app",
-  "version": "6.13.2",
+  "version": "6.13.3",
   "description": "This package has Eslint configurations used by one-app.",
   "main": "index.js",
   "jest": {

--- a/packages/generator-one-app-module/CHANGELOG.md
+++ b/packages/generator-one-app-module/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.12.6](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/generator-one-app-module@6.12.3...@americanexpress/generator-one-app-module@6.12.6) (2023-02-16)
+
+**Note:** Version bump only for package @americanexpress/generator-one-app-module
+
+
+
+
+
 ## [6.12.5](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/generator-one-app-module@6.12.3...@americanexpress/generator-one-app-module@6.12.5) (2022-11-16)
 
 **Note:** Version bump only for package @americanexpress/generator-one-app-module

--- a/packages/generator-one-app-module/package.json
+++ b/packages/generator-one-app-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/generator-one-app-module",
-  "version": "6.12.5",
+  "version": "6.12.6",
   "description": "generator for One App Modules",
   "license": "Apache-2.0",
   "contributors": [

--- a/packages/holocron-dev-server/CHANGELOG.md
+++ b/packages/holocron-dev-server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.8](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/holocron-dev-server@0.1.5...@americanexpress/holocron-dev-server@0.1.8) (2023-02-16)
+
+**Note:** Version bump only for package @americanexpress/holocron-dev-server
+
+
+
+
+
 ## [0.1.7](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/holocron-dev-server@0.1.5...@americanexpress/holocron-dev-server@0.1.7) (2022-11-16)
 
 **Note:** Version bump only for package @americanexpress/holocron-dev-server

--- a/packages/holocron-dev-server/package.json
+++ b/packages/holocron-dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/holocron-dev-server",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A micro-frontend dev server for Holocron Modules",
   "license": "Apache-2.0",
   "keywords": [
@@ -38,7 +38,7 @@
   "module": "src/index.js",
   "dependencies": {
     "@americanexpress/fetch-enhancers": "^1.0.3",
-    "@americanexpress/one-app-bundler": "^6.15.4",
+    "@americanexpress/one-app-bundler": "^6.17.0",
     "@americanexpress/one-app-ducks": "^4.1.1",
     "@americanexpress/one-app-router": "^1.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-beta.1",

--- a/packages/one-app-bundler/CHANGELOG.md
+++ b/packages/one-app-bundler/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [6.17.0](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.15.2...@americanexpress/one-app-bundler@6.17.0) (2023-02-16)
+
+
+### Bug Fixes
+
+* **hash:** use OpenSSL supported hash for webpack ([#488](https://github.com/americanexpress/one-app-cli/issues/488)) ([7c6660a](https://github.com/americanexpress/one-app-cli/commit/7c6660a4a345f075603080a7203b8e84f64bb5d8))
+
+
+### Features
+
+* **bundler:** enable dev bundler through flag ([1cc171b](https://github.com/americanexpress/one-app-cli/commit/1cc171bffec3c4f4da8aa3689eb9c3e10dd89870))
+
+
+
+
+
 # [6.16.0](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.15.2...@americanexpress/one-app-bundler@6.16.0) (2023-01-05)
 
 

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-bundler",
-  "version": "6.16.0",
+  "version": "6.17.0",
   "description": "A command line interface(CLI) tool for bundling One App and its modules.",
   "main": "index.js",
   "bin": {
@@ -38,9 +38,9 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@americanexpress/eslint-plugin-one-app": "^6.13.2",
-    "@americanexpress/one-app-dev-bundler": "^1.1.0",
-    "@americanexpress/one-app-locale-bundler": "^6.5.5",
+    "@americanexpress/eslint-plugin-one-app": "^6.13.3",
+    "@americanexpress/one-app-dev-bundler": "^1.2.0",
+    "@americanexpress/one-app-locale-bundler": "^6.5.6",
     "@americanexpress/purgecss-loader": "^2.0.0",
     "@babel/core": "^7.17.5",
     "@babel/eslint-parser": "^7.17.0",

--- a/packages/one-app-dev-bundler/CHANGELOG.md
+++ b/packages/one-app-dev-bundler/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.2.0 (2023-02-16)
+
+
+### Bug Fixes
+
+* **indexloader:** regex was failing on windows machines ([#494](https://github.com/americanexpress/one-app-cli/issues/494)) ([aadd37f](https://github.com/americanexpress/one-app-cli/commit/aadd37faea92fce9b6c691c061441e1624f40cb1))
+
+
+### Features
+
+* **bundler:** enable dev bundler through flag ([1cc171b](https://github.com/americanexpress/one-app-cli/commit/1cc171bffec3c4f4da8aa3689eb9c3e10dd89870))
+* **devBundler:** add dev bundler ([ff0b49d](https://github.com/americanexpress/one-app-cli/commit/ff0b49dd83d0bbe02c87d111c3fbd512fa53200a))
+
+
+
+
+
 # 1.1.0 (2023-01-05)
 
 

--- a/packages/one-app-dev-bundler/package.json
+++ b/packages/one-app-dev-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-dev-bundler",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A development bundler focussed on speed and modern features.",
   "main": "index.js",
   "bin": {
@@ -25,7 +25,7 @@
   "module": "true",
   "type": "module",
   "dependencies": {
-    "@americanexpress/one-app-locale-bundler": "^6.5.1",
+    "@americanexpress/one-app-locale-bundler": "^6.5.6",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
     "@fullhuman/postcss-purgecss": "3.0.0",

--- a/packages/one-app-locale-bundler/CHANGELOG.md
+++ b/packages/one-app-locale-bundler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.5.6](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-locale-bundler@6.5.3...@americanexpress/one-app-locale-bundler@6.5.6) (2023-02-16)
+
+**Note:** Version bump only for package @americanexpress/one-app-locale-bundler
+
+
+
+
+
 ## [6.5.5](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-locale-bundler@6.5.3...@americanexpress/one-app-locale-bundler@6.5.5) (2022-11-16)
 
 **Note:** Version bump only for package @americanexpress/one-app-locale-bundler

--- a/packages/one-app-locale-bundler/package.json
+++ b/packages/one-app-locale-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-locale-bundler",
-  "version": "6.5.5",
+  "version": "6.5.6",
   "description": "A command line interface(CLI) tool for bundling the locale files.",
   "bin": {
     "bundle-module-locale": "./bin/bundle-module-locale.js"

--- a/packages/one-app-runner/CHANGELOG.md
+++ b/packages/one-app-runner/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.14.4](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.14.0...@americanexpress/one-app-runner@6.14.4) (2023-02-16)
+
+
+### Bug Fixes
+
+* **module:** module not found waitForOk ([#479](https://github.com/americanexpress/one-app-cli/issues/479)) ([56cc127](https://github.com/americanexpress/one-app-cli/commit/56cc12797d7c4cd08143b48bb0041fe27e966650))
+* **race-issue:** docker race issue ([#474](https://github.com/americanexpress/one-app-cli/issues/474)) ([e5ebd36](https://github.com/americanexpress/one-app-cli/commit/e5ebd3616d79bf4956e53f0b7f5a980bddac26fc))
+
+
+
+
+
 ## [6.14.3](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.14.0...@americanexpress/one-app-runner@6.14.3) (2023-01-05)
 
 

--- a/packages/one-app-runner/package.json
+++ b/packages/one-app-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-runner",
-  "version": "6.14.3",
+  "version": "6.14.4",
   "description": "CLI for running One App locally",
   "license": "Apache-2.0",
   "contributors": [


### PR DESCRIPTION
 - @americanexpress/eslint-plugin-one-app@6.13.3
 - @americanexpress/generator-one-app-module@6.12.6
 - @americanexpress/holocron-dev-server@0.1.8
 - @americanexpress/one-app-bundler@6.17.0
 - @americanexpress/one-app-dev-bundler@1.2.0
 - @americanexpress/one-app-locale-bundler@6.5.6
 - @americanexpress/one-app-runner@6.14.4

#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_

Release a bugfix for the one-app-dev-bundler to support Windows machiens

