### PR TITLE
fix(one-app-dev-bundler): index loader filter for Windows paths

### DIFF
--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader.spec.js
@@ -84,8 +84,14 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
       const lifeCycleHooks = runSetupAndGetLifeHooks(plugin);
 
       expect(lifeCycleHooks.onLoad.length).toBe(1);
-      // eslint-disable-next-line prefer-regex-literals -- needs to match exactly
-      expect(lifeCycleHooks.onLoad[0].config).toEqual({ filter: new RegExp('[\\/]modules[\\/]src[\\/]index') });
+      expect(lifeCycleHooks.onLoad[0].config).toHaveProperty('filter', expect.any(RegExp));
+      const { filter } = lifeCycleHooks.onLoad[0].config;
+      // *nix
+      expect('/home/me/projects/modules/src/index.js').toMatch(filter);
+      expect('/home/me/projects/modules/src/components/index.js').not.toMatch(filter);
+      // Windows
+      expect('C:\\Users\\me\\projects\\modules\\src\\index.js').toMatch(filter);
+      expect('C:\\Users\\me\\projects\\modules\\src\\components\\index.js').not.toMatch(filter);
     });
   });
 

--- a/packages/one-app-dev-bundler/esbuild/plugins/one-app-index-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/one-app-index-loader.js
@@ -47,9 +47,18 @@ const oneAppIndexLoader = (options) => ({
       new DevLiveReloaderInjector(injectorOptions),
     ];
 
-    const packageRoot = packageJsonPath.replace(`${path.sep}package.json`, '');
-    const folderName = packageRoot.split(path.sep).pop();
-    const filterRegex = new RegExp(`[\\/]${folderName}[\\/]src[\\/]index`);
+    const packageRoot = path.dirname(packageJsonPath);
+    const folderName = path.basename(packageRoot);
+    // this is a String being parsed to build a RegExp
+    // to match both OS slashes we need \ & / (C:\Users, /home)
+    // both to be escaped in a String
+    // but \ needs to be escaped for the RegExp (once) which is built from a String (second escape)
+    // thus \ turns into \\\\ (\\\\ -> String of \\ -> RegExp of \)
+    // and / into \\/ (\\/ -> String of \/ -> RegExp of /)
+    // usually () indicate a capture group, but we want to specify two options (|)
+    // we can tell the RegExp engine not to store the slash as a capture group using ?:
+    // so the full way to specify a path delineator slash of either \ or / is (?:\\/|\\\\)
+    const filterRegex = new RegExp(`(?:\\/|\\\\)${folderName}(?:\\/|\\\\)src(?:\\/|\\\\)index`);
 
     build.onLoad({ filter: filterRegex }, async (args) => {
       const initialContent = await fs.promises.readFile(args.path, 'utf8');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->
## **Description**
<!-- _Describe your changes in detail_ -->
esbuild plugins must specify a filter as a RegExp, as the source property is used. As the plugins are specifically for the module entrypoint, the folder name is included for specificity. This means we need to build a String to build the RegExp filter. Unfortunately, this double conversion means we need to double escape slashes.
> this is a String being parsed to build a RegExp
to match both OS slashes we need `\` & `/` (`C:\Users`, `/home`)
both to be escaped in a String
but `\` needs to be escaped for the RegExp (once) which is built from a String (second escape)
thus `\` turns into `\\\\` (`\\\\` -> String of `\\` -> RegExp of `\`)
and `/` into `\\/` (`\\/` -> String of `\/` -> RegExp of `/`)
usually `()` indicate a capture group, but we want to specify two options `(|)`
we can tell the RegExp engine not to store the slash as a capture group using `?:`
so the full way to specify a path delineator slash of either `\` or `/` is `(?:\\/|\\\\)`

Additionally, [Node.js path methods](https://nodejs.org/dist/latest-v18.x/docs/api/path.html#pathdirnamepath) were used to avoid the treacherous path of manually editing paths.

<!-- _This project only accepts pull requests related to open issues._ -->
<!-- _If suggesting a new feature or change, please discuss it in an issue first._ -->


## **Motivation** 
<!-- _Why is this change required? What issue does it resolve?_ -->
Users are seeing issues loading modules when building in Windows. The holocron metadata like version is not being added.

## **Test** **Conditions**
<!-- _Describe in detail how the changes are tested._ -->
<!-- _Include details of your testing environment, and the tests you ran to._ -->
<!-- _How does your change affect the rest of the code._ -->
Change the existing test to instead test the filter on paths for both *nix (Linux, BSD) and Windows. Editing the test first without the unit edits resulted in a test failure, so regressions will be caught.

The frank-lloyd-root sample module in the one-app repository was used to reproduce the issue and verify the change (giving additional confidence to the new test expectations).

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
