### PR TITLE
fix(one-app-dev-bundler): match a period, rather than wildcard

### DIFF
--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/font-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/font-loader.spec.js
@@ -29,8 +29,25 @@ describe('Esbuild image loader', () => {
   describe('setup function', () => {
     it('should register an onLoad hook, with the right filters for all bundles', () => {
       const lifeCycleHooks = runSetupAndGetLifeHooks(fontLoader);
-      expect(lifeCycleHooks.onLoad.length).toBe(1);
-      expect(lifeCycleHooks.onLoad[0].config).toEqual({ filter: /.ttf$|.woff$|.woff2$|.jfproj$/ });
+      expect(lifeCycleHooks).toHaveProperty('onLoad.0.config.filter', expect.any(RegExp));
+      expect(lifeCycleHooks.onLoad).toHaveLength(1);
+    });
+
+    it.each([
+      ['/home/me/projects/modules/src/components/font.ttf'],
+      ['/home/me/projects/modules/src/components/font.TTF'],
+      ['/home/me/projects/modules/src/components/font.woff'],
+      ['/home/me/projects/modules/src/components/font.WOFF'],
+      ['/home/me/projects/modules/src/components/font.woff2'],
+      ['/home/me/projects/modules/src/components/font.WOFF2'],
+      ['/home/me/projects/modules/src/components/font.jfproj'],
+      ['/home/me/projects/modules/src/components/font.JFPROJ'],
+    ])('should register an onLoad hook for a resource like %s', (filePath) => {
+      const lifeCycleHooks = runSetupAndGetLifeHooks(fontLoader);
+      expect(lifeCycleHooks.onLoad).toHaveLength(1);
+      expect(lifeCycleHooks).toHaveProperty('onLoad.0.config.filter', expect.any(RegExp));
+      const { filter } = lifeCycleHooks.onLoad[0].config;
+      expect(filePath).toMatch(filter);
     });
   });
 });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/image-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/image-loader.spec.js
@@ -29,8 +29,23 @@ describe('Esbuild image loader', () => {
   describe('setup function', () => {
     it('should register an onLoad hook, with the right filters for all bundles', () => {
       const lifeCycleHooks = runSetupAndGetLifeHooks(imageLoader);
-      expect(lifeCycleHooks.onLoad.length).toBe(1);
-      expect(lifeCycleHooks.onLoad[0].config).toEqual({ filter: /\.png$|\.jpg$|\.jpeg$|\.svg$/ });
+      expect(lifeCycleHooks).toHaveProperty('onLoad.0.config.filter', expect.any(RegExp));
+      expect(lifeCycleHooks.onLoad).toHaveLength(1);
+    });
+
+    it.each([
+      ['/home/me/projects/modules/src/components/image.png'],
+      ['/home/me/projects/modules/src/components/image.PNG'],
+      ['/home/me/projects/modules/src/components/image.jpeg'],
+      ['/home/me/projects/modules/src/components/image.JPEG'],
+      ['/home/me/projects/modules/src/components/image.jpg'],
+      ['/home/me/projects/modules/src/components/image.JPG'],
+      ['/home/me/projects/modules/src/components/image.svg'],
+      ['/home/me/projects/modules/src/components/image.SVG'],
+    ])('should register an onLoad hook for a resource like %s', (filePath) => {
+      const lifeCycleHooks = runSetupAndGetLifeHooks(imageLoader);
+      expect(lifeCycleHooks).toHaveProperty('onLoad.0.config.filter', expect.any(RegExp));
+      expect(filePath).toMatch(lifeCycleHooks.onLoad[0].config.filter);
     });
   });
 });

--- a/packages/one-app-dev-bundler/esbuild/plugins/externals-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/externals-loader.js
@@ -29,6 +29,7 @@ const externalsLoader = ({ bundleType }) => ({
     const globalReferenceString = bundleType === BUNDLE_TYPES.BROWSER ? 'globalThis' : 'global';
 
     requiredExternalNames.forEach((requiredExternalName) => {
+      // FIXME: escape characters
       const filterRegex = new RegExp(`^${requiredExternalName}$`);
 
       build.onResolve({ filter: filterRegex }, (args) => ({ path: args.path, namespace: 'externalsLoader' }));

--- a/packages/one-app-dev-bundler/esbuild/plugins/font-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/font-loader.js
@@ -19,7 +19,7 @@ import fs from 'fs';
 const fontLoader = {
   name: 'fontLoader',
   setup(build) {
-    build.onLoad({ filter: /.ttf$|.woff$|.woff2$|.jfproj$/ }, async (args) => {
+    build.onLoad({ filter: /\.(ttf|woff2?|jfproj)$/i }, async (args) => {
       const dataurl = await fs.promises.readFile(args.path, 'base64');
       const fileType = args.path.split('.').pop();
       const jsContent = `module.exports = "data:font/${fileType};base64,${dataurl}"`;

--- a/packages/one-app-dev-bundler/esbuild/plugins/image-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/image-loader.js
@@ -19,7 +19,7 @@ import fs from 'fs';
 const imageLoader = {
   name: 'imageLoader',
   setup(build) {
-    build.onLoad({ filter: /\.png$|\.jpg$|\.jpeg$|\.svg$/ }, async (args) => {
+    build.onLoad({ filter: /\.(png|jpe?g|svg)$/i }, async (args) => {
       const dataurl = await fs.promises.readFile(args.path, 'base64');
       let fileType = args.path.split('.').pop();
       if (fileType === 'svg') {


### PR DESCRIPTION
## **Description**
- match a period, rather than wildcard: `.` to `\.`
- case insensitive on file extensions: `i` flag 
  - `image.JPG` is an older way of naming files, kind of like HTML tags, but not invalid, may also save a dev some frustration when using both sensitive and insensitive filesystems (Linux, macOS)
- simplify suffix variations: e.g. `e` is commonly left out in `jpeg` (convention stemming from a previous Windows? 5+3 rule) so `jpe?g` is a compact way to specify both (note that we're already using `s?css` to match `css` and `scss`)

## **Motivation** 
From #507 I figured a walkthrough of other RegExp's might be useful, just in case. I didn't find any other slash issues, so this PR might just be #nitpicky 😅  

## **Test** **Conditions**
~~unchanged for brevity, but would it be preferred to add scenarios similar to #507?~~
Added sample paths, albeit just Unix style & not Windows, but not sure we need the latter for these filters?

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
