### PR TITLE
fix(locale-bundler): do not exit on errors during watch

### DIFF
--- a/packages/one-app-locale-bundler/__tests__/index.spec.js
+++ b/packages/one-app-locale-bundler/__tests__/index.spec.js
@@ -61,17 +61,16 @@ describe('index', () => {
   });
 
   it('throws on initial error', async () => {
-    compileModuleLocales.mockRejectedValueOnce(new SyntaxError('some error'))
+    compileModuleLocales.mockRejectedValueOnce(new SyntaxError('some error'));
     await expect(async () => {
       await index();
       jest.runAllTimers();
     }).rejects.toThrowError(new SyntaxError('some error'));
-
   });
 
   it('logs to console on error during watch', async () => {
     index(true);
-    compileModuleLocales.mockRejectedValueOnce(new SyntaxError('some error'))
+    compileModuleLocales.mockRejectedValueOnce(new SyntaxError('some error'));
     await chokidar.on.mock.calls[0][1]();
     jest.runAllTimers();
     expect(consoleLogSpy).toHaveBeenCalledTimes(1);

--- a/packages/one-app-locale-bundler/index.js
+++ b/packages/one-app-locale-bundler/index.js
@@ -19,9 +19,15 @@ const compileModuleLocales = require('./src/compileModuleLocales');
 function runLocaleBundler(modulePath) {
   return compileModuleLocales(modulePath)
     .catch((err) => {
-      /* istanbul ignore next */
       setTimeout(() => { throw err; });
     });
+}
+
+function runLocaleBundlerLogErrors(modulePath) {
+  return compileModuleLocales(modulePath)
+      .catch((err) => {
+        console.log('Error generating language packs: '+err);
+      });
 }
 
 module.exports = function localeBundler(watch) {
@@ -33,6 +39,6 @@ module.exports = function localeBundler(watch) {
     const inputPath = path.join(modulePath, 'locale');
     chokidar
       .watch(inputPath, { ignoreInitial: true })
-      .on('all', () => runLocaleBundler(modulePath));
+      .on('all', () => runLocaleBundlerLogErrors(modulePath));
   }
 };

--- a/packages/one-app-locale-bundler/index.js
+++ b/packages/one-app-locale-bundler/index.js
@@ -25,9 +25,9 @@ function runLocaleBundler(modulePath) {
 
 function runLocaleBundlerLogErrors(modulePath) {
   return compileModuleLocales(modulePath)
-      .catch((err) => {
-        console.log('Error generating language packs: '+err);
-      });
+    .catch((err) => {
+      console.log(`Error generating language packs: ${err}`);
+    });
 }
 
 module.exports = function localeBundler(watch) {


### PR DESCRIPTION
## **Description**

Prints a console log message instead of throwing an error if an error is encountered in watch mode.  If not in watch mode, existing behavior of exiting immediately is unchanged.

## **Motivation** 
Fixes #510 

Having the watch mode ever exit on errors leads to a worse developer experience, since any additional code changes will not be built.

## **Test** **Conditions**

Tested with unit tests and by making the change in local version of locale-bundler.

This shows a locale file having a syntax error introduced and then removed, and being rebuilt after it was fixed:
```
$ npm run watch:build

> project@1.0.0 watch:build
> bundle-module --dev --watch

Running dev bundler
Generated language packs for en-US
Watching...
Error generating language packs: SyntaxError: Unexpected token 
 in JSON at position 5398
Generated language packs for en-US
```

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
