### PR TITLE
fix(dev-bundler): skip plugins when no results metadata

### DIFF
--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/bundle-asset-size-limiter.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/bundle-asset-size-limiter.spec.js
@@ -230,5 +230,20 @@ Array [
 `);
       });
     });
+
+    it('should do nothing if there is no results metadata', async () => {
+      expect.assertions(2);
+
+      getModulesBundlerConfig.mockImplementation(() => null);
+      getModulesWebpackConfig.mockImplementation(() => null);
+
+      const plugin = bundleAssetSizeLimiter({ ...params });
+      const onEnd = runSetupAndGetLifeHooks(plugin).onEnd[0];
+
+      const output = await onEnd({});
+
+      expect(console).not.toHaveLogs();
+      expect(output.messages).toBe(undefined);
+    });
   });
 });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/cjs-compatibility-hotpatch.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/cjs-compatibility-hotpatch.spec.js
@@ -76,8 +76,8 @@ describe('Esbuild plugin cjsCompatibilityHotpatch', () => {
 
       await onEnd({});
 
-      expect(fs.promises.readFile).toHaveBeenCalledTimes(0);
-      expect(fs.promises.writeFile).toHaveBeenCalledTimes(0);
+      expect(fs.promises.readFile).not.toHaveBeenCalled();
+      expect(fs.promises.writeFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/cjs-compatibility-hotpatch.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/cjs-compatibility-hotpatch.spec.js
@@ -63,10 +63,21 @@ describe('Esbuild plugin cjsCompatibilityHotpatch', () => {
         expect(fs.promises.readFile).toHaveBeenCalledTimes(1);
         expect(fs.promises.readFile).toHaveBeenCalledWith('mock/file/name.js', 'utf8');
 
-        expect(fs.promises.readFile).toHaveBeenCalledTimes(1);
+        expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
         expect(fs.promises.writeFile).toHaveBeenCalledWith('mock/file/name.js', `const mock = "JavaScript Content";
 ;module.exports = src_default;`, 'utf8');
       });
+    });
+
+    it('should do nothing if there is no results metadata', async () => {
+      expect.assertions(2);
+
+      const onEnd = runSetupAndGetLifeHooks(cjsCompatibilityHotpatch).onEnd[0];
+
+      await onEnd({});
+
+      expect(fs.promises.readFile).toHaveBeenCalledTimes(0);
+      expect(fs.promises.writeFile).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/generate-integrity-manifest.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/generate-integrity-manifest.spec.js
@@ -123,8 +123,8 @@ describe('Esbuild plugin generateIntegrityManifest', () => {
         const onEnd = hooks.onEnd[0];
         await onEnd({});
 
-        expect(fs.promises.readFile).toHaveBeenCalledTimes(0);
-        expect(fs.promises.writeFile).toHaveBeenCalledTimes(0);
+        expect(fs.promises.readFile).not.toHaveBeenCalled();
+        expect(fs.promises.writeFile).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/generate-integrity-manifest.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/generate-integrity-manifest.spec.js
@@ -115,6 +115,17 @@ describe('Esbuild plugin generateIntegrityManifest', () => {
         expect(results).toBe(mockResult);
         expect(results).toStrictEqual(mockResult);
       });
+
+      it('should do nothing if there is no results metadata', async () => {
+        expect.assertions(2);
+        const plugin = generateIntegrityManifest({ bundleName: 'mockBundleName' });
+        const hooks = runSetupAndGetLifeHooks(plugin);
+        const onEnd = hooks.onEnd[0];
+        await onEnd({});
+
+        expect(fs.promises.readFile).toHaveBeenCalledTimes(0);
+        expect(fs.promises.writeFile).toHaveBeenCalledTimes(0);
+      });
     });
   });
 });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/restrict-runtime-symbols.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/restrict-runtime-symbols.spec.js
@@ -217,6 +217,21 @@ if(false) {
           ]
         `);
       });
+
+      it('should do nothing if there is no results metadata', async () => {
+        expect.assertions(2);
+
+        const plugin = restrictRuntimeSymbols({
+          severity: SEVERITY.WARNING,
+          bundleType: BUNDLE_TYPES.BROWSER,
+        });
+        const onEnd = runSetupAndGetLifeHooks(plugin).onEnd[0];
+
+        await onEnd({});
+
+        expect(logWarnings).not.toHaveBeenCalled();
+        expect(logErrors).not.toHaveBeenCalled();
+      });
     });
 
     describe('onEnd for server bundles', () => {
@@ -257,6 +272,22 @@ if(false) {
             "\`create-react-class\` is restricted from being used",
           ]
         `);
+      });
+
+      it('should do nothing if there is no results metadata', async () => {
+        expect.assertions(2);
+
+        const plugin = restrictRuntimeSymbols({
+          severity: SEVERITY.WARNING,
+          bundleType: BUNDLE_TYPES.SERVER,
+        });
+        const onEnd = runSetupAndGetLifeHooks(plugin).onEnd[0];
+
+        const mockResult = {};
+        await onEnd(mockResult);
+
+        expect(logWarnings).not.toHaveBeenCalled();
+        expect(logErrors).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/server-styles-dispatcher.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/server-styles-dispatcher.spec.js
@@ -70,6 +70,28 @@ describe('server styles dispatcher', () => {
 
       /* onEnd test end */
     });
+
+    it('should do nothing if there is no results metadata', async () => {
+      expect.assertions(1);
+
+      // get the hooks
+      const hooks = runSetupAndGetLifeHooks(
+        serverStylesDispatcher({ bundleType: BUNDLE_TYPES.SERVER })
+      );
+      const onEnd = hooks.onEnd[0];
+
+      // mock the bundle using mockFs
+      mockFs(
+        { [mockBundleFileName]: 'const mock = "JavaScript Content";' },
+        { createCwd: false, createTmp: false }
+      );
+      await onEnd({});
+
+      // since this test uses mockFs, and onEnd writes the file, read it to verify it is unchanged
+      const actualBundleContent = await fs.promises.readFile(mockBundleFileName, 'utf8');
+      mockFs.restore();
+      expect(actualBundleContent).toMatchInlineSnapshot('"const mock = \\"JavaScript Content\\";"');
+    });
   });
   describe('bundle type browser', () => {
     it('registers no hooks', () => {

--- a/packages/one-app-dev-bundler/esbuild/plugins/bundle-asset-size-limiter.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/bundle-asset-size-limiter.js
@@ -26,6 +26,10 @@ const bundleAssetSizeLimiter = ({ watch, severity }) => ({
   name: 'bundleAssetSizeLimiter',
   setup(build) {
     build.onEnd(async (result) => {
+      if (!result.metafile) {
+        return result;
+      }
+
       // get filenames and sizes of outputs in this build
       const fileNames = getJsFilenamesFromKeys(result.metafile.outputs);
       const sizes = fileNames.map((fileName) => result.metafile.outputs[fileName].bytes);

--- a/packages/one-app-dev-bundler/esbuild/plugins/cjs-compatibility-hotpatch.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/cjs-compatibility-hotpatch.js
@@ -27,6 +27,9 @@ const cjsCompatibilityHotpatch = {
   name: 'cjsCompatibilityHotpatch',
   setup(build) {
     build.onEnd(async (result) => {
+      if (!result.metafile) {
+        return result;
+      }
       const fileNames = getJsFilenamesFromKeys(result.metafile.outputs);
       await Promise.all(fileNames.map(async (fileName) => {
         const initialContent = await fs.promises.readFile(fileName, 'utf8');

--- a/packages/one-app-dev-bundler/esbuild/plugins/generate-integrity-manifest.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/generate-integrity-manifest.js
@@ -35,6 +35,9 @@ const generateIntegrityManifest = ({ bundleName }) => ({
   name: 'generateIntegrityManifest',
   setup(build) {
     build.onEnd(async (result) => {
+      if (!result.metafile) {
+        return result;
+      }
       // this boldly assumes there will be exactly 1 .js file emitted from the build
       const fileName = getJsFilenamesFromKeys(result.metafile.outputs)[0];
 

--- a/packages/one-app-dev-bundler/esbuild/plugins/restrict-runtime-symbols.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/restrict-runtime-symbols.js
@@ -129,6 +129,9 @@ const restrictRuntimeSymbols = ({ severity, bundleType }) => ({
   name: 'restrictRuntimeSymbols',
   setup(build) {
     build.onEnd(async (result) => {
+      if (!result.metafile) {
+        return;
+      }
       const fileNames = getJsFilenamesFromKeys(result.metafile.outputs);
       const isBrowser = bundleType === BUNDLE_TYPES.BROWSER;
       // eslint-disable-next-line no-restricted-syntax -- traditional for loop for looped async work

--- a/packages/one-app-dev-bundler/esbuild/plugins/server-styles-dispatcher.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/server-styles-dispatcher.js
@@ -24,6 +24,9 @@ const serverStylesDispatcher = ({ bundleType }) => ({
   setup(build) {
     if (bundleType === BUNDLE_TYPES.SERVER) {
       build.onEnd(async (result) => {
+        if (!result.metafile) {
+          return result;
+        }
         const fileNames = getJsFilenamesFromKeys(result.metafile.outputs);
         await Promise.all(fileNames.map(async (fileName) => {
           const initialContent = await fs.promises.readFile(fileName, 'utf8');


### PR DESCRIPTION
## **Description**
Do not run the `onEnd` plugins when the results metadata is not defined.

Fixes #512 

## **Motivation** 

When the build fails due to a syntax error or similar, the `onEnd` plugins are called with a results object that does not have a `metadata` key.  Most of the plugins have reference to `result.metafile.outputs` so they themselves throw an error, which thoroughly obscures the original syntax error.

## **Test** **Conditions**

Unit tests plus ran changes locally.  Output shows only the two relevant failures, rather than pages of stack traces.
```
* $ npm run watch:build

> package@1.0.0 watch:build
> bundle-module --dev --watch

Running dev bundler
Generated language packs for en-US
Watching...
✘ [ERROR] Could not resolve "./Dynamic Table"

    src/components/history/History.jsx:9:39:
      9 │ import DynamicTable from './Dynamic Table';
        ╵                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

✘ [ERROR] Could not resolve "./Dynamic Table"

    src/components/history/History.jsx:9:39:
      9 │ import DynamicTable from './Dynamic Table';
        ╵                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Server bundle failed, see above for reason
Browser bundle failed, see above for reason
Browser bundle built in 1068ms
Server bundle built in 1087ms
```

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
