### PR TITLE
chore(release): publish packages

### DIFF
--- a/packages/holocron-dev-server/CHANGELOG.md
+++ b/packages/holocron-dev-server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.11](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/holocron-dev-server@0.1.10...@americanexpress/holocron-dev-server@0.1.11) (2023-04-07)
+
+**Note:** Version bump only for package @americanexpress/holocron-dev-server
+
+
+
+
+
 ## [0.1.10](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/holocron-dev-server@0.1.9...@americanexpress/holocron-dev-server@0.1.10) (2023-03-16)
 
 **Note:** Version bump only for package @americanexpress/holocron-dev-server

--- a/packages/holocron-dev-server/package.json
+++ b/packages/holocron-dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/holocron-dev-server",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A micro-frontend dev server for Holocron Modules",
   "license": "Apache-2.0",
   "keywords": [
@@ -38,7 +38,7 @@
   "module": "src/index.js",
   "dependencies": {
     "@americanexpress/fetch-enhancers": "^1.0.3",
-    "@americanexpress/one-app-bundler": "^6.18.1",
+    "@americanexpress/one-app-bundler": "^6.18.2",
     "@americanexpress/one-app-ducks": "^4.1.1",
     "@americanexpress/one-app-router": "^1.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-beta.1",

--- a/packages/one-app-bundler/CHANGELOG.md
+++ b/packages/one-app-bundler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.18.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.18.1...@americanexpress/one-app-bundler@6.18.2) (2023-04-07)
+
+**Note:** Version bump only for package @americanexpress/one-app-bundler
+
+
+
+
+
 ## [6.18.1](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.18.0...@americanexpress/one-app-bundler@6.18.1) (2023-03-16)
 
 **Note:** Version bump only for package @americanexpress/one-app-bundler

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-bundler",
-  "version": "6.18.1",
+  "version": "6.18.2",
   "description": "A command line interface(CLI) tool for bundling One App and its modules.",
   "main": "index.js",
   "bin": {
@@ -39,8 +39,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@americanexpress/eslint-plugin-one-app": "^6.13.4",
-    "@americanexpress/one-app-dev-bundler": "^1.3.1",
-    "@americanexpress/one-app-locale-bundler": "^6.5.7",
+    "@americanexpress/one-app-dev-bundler": "^1.3.2",
+    "@americanexpress/one-app-locale-bundler": "^6.5.8",
     "@americanexpress/purgecss-loader": "^2.0.0",
     "@babel/core": "^7.17.5",
     "@babel/eslint-parser": "^7.17.0",

--- a/packages/one-app-dev-bundler/CHANGELOG.md
+++ b/packages/one-app-dev-bundler/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-dev-bundler@1.3.1...@americanexpress/one-app-dev-bundler@1.3.2) (2023-04-07)
+
+
+### Bug Fixes
+
+* **dev-bundler:** skip plugins when no results metadata ([#513](https://github.com/americanexpress/one-app-cli/issues/513)) ([76b5566](https://github.com/americanexpress/one-app-cli/commit/76b5566b1d74a5686c31fbbb24c496e6b8af59db))
+* **one-app-dev-bundler:** index loader filter for Windows paths ([#507](https://github.com/americanexpress/one-app-cli/issues/507)) ([a6b66e9](https://github.com/americanexpress/one-app-cli/commit/a6b66e99d7b9e77b76714b772c9d7f116191bcc0))
+* **one-app-dev-bundler:** match a period, rather than wildcard ([#508](https://github.com/americanexpress/one-app-cli/issues/508)) ([490f74b](https://github.com/americanexpress/one-app-cli/commit/490f74b43aca5bf1cb1bd0cb88deab2af60c11b7))
+
+
+
+
+
 ## [1.3.1](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-dev-bundler@1.3.0...@americanexpress/one-app-dev-bundler@1.3.1) (2023-03-16)
 
 

--- a/packages/one-app-dev-bundler/package.json
+++ b/packages/one-app-dev-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-dev-bundler",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A development bundler focussed on speed and modern features.",
   "main": "index.js",
   "bin": {
@@ -25,7 +25,7 @@
   "module": "true",
   "type": "module",
   "dependencies": {
-    "@americanexpress/one-app-locale-bundler": "^6.5.7",
+    "@americanexpress/one-app-locale-bundler": "^6.5.8",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@fal-works/esbuild-plugin-global-externals": "^2.1.2",

--- a/packages/one-app-locale-bundler/CHANGELOG.md
+++ b/packages/one-app-locale-bundler/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.5.8](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-locale-bundler@6.5.7...@americanexpress/one-app-locale-bundler@6.5.8) (2023-04-07)
+
+
+### Bug Fixes
+
+* **locale-bundler:** do not exit on errors during watch ([#511](https://github.com/americanexpress/one-app-cli/issues/511)) ([f0fd6f8](https://github.com/americanexpress/one-app-cli/commit/f0fd6f8da23a6f7b9e2e1973aea559e5b53b4c1e))
+
+
+
+
+
 ## [6.5.7](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-locale-bundler@6.5.3...@americanexpress/one-app-locale-bundler@6.5.7) (2023-03-08)
 
 **Note:** Version bump only for package @americanexpress/one-app-locale-bundler

--- a/packages/one-app-locale-bundler/package.json
+++ b/packages/one-app-locale-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-locale-bundler",
-  "version": "6.5.7",
+  "version": "6.5.8",
   "description": "A command line interface(CLI) tool for bundling the locale files.",
   "bin": {
     "bundle-module-locale": "./bin/bundle-module-locale.js"


### PR DESCRIPTION
 - @americanexpress/holocron-dev-server@0.1.11
 - @americanexpress/one-app-bundler@6.18.2
 - @americanexpress/one-app-dev-bundler@1.3.2
 - @americanexpress/one-app-locale-bundler@6.5.8

## @americanexpress/one-app-dev-bundler 
### Bug Fixes
* **dev-bundler:** skip plugins when no results metadata ([#513](https://github.com/americanexpress/one-app-cli/issues/513)) ([76b5566](https://github.com/americanexpress/one-app-cli/commit/76b5566b1d74a5686c31fbbb24c496e6b8af59db))
* **one-app-dev-bundler:** index loader filter for Windows paths ([#507](https://github.com/americanexpress/one-app-cli/issues/507)) ([a6b66e9](https://github.com/americanexpress/one-app-cli/commit/a6b66e99d7b9e77b76714b772c9d7f116191bcc0))
* **one-app-dev-bundler:** match a period, rather than wildcard ([#508](https://github.com/americanexpress/one-app-cli/issues/508)) ([490f74b](https://github.com/americanexpress/one-app-cli/commit/490f74b43aca5bf1cb1bd0cb88deab2af60c11b7))

## @americanexpress/one-app-locale-bundler
### Bug Fixes
* **locale-bundler:** do not exit on errors during watch ([#511](https://github.com/americanexpress/one-app-cli/issues/511)) ([f0fd6f8](https://github.com/americanexpress/one-app-cli/commit/f0fd6f8da23a6f7b9e2e1973aea559e5b53b4c1e))