### PR TITLE
feat(typeScript): allow bundlers to consume ts files

### DIFF
--- a/packages/one-app-bundler/webpack/module/webpack.client.js
+++ b/packages/one-app-bundler/webpack/module/webpack.client.js
@@ -55,7 +55,7 @@ module.exports = (babelEnv) => {
       resolve: {
         mainFields: ['browser', 'module', 'main'],
         modules: [packageRoot, 'node_modules'],
-        extensions: ['.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
       node: { module: 'empty', net: 'empty', fs: 'empty' },
       performance: {
@@ -66,7 +66,7 @@ module.exports = (babelEnv) => {
       module: {
         rules: [
           {
-            test: /\.jsx?$/,
+            test: /[jt]sx?$/,
             include: [path.join(packageRoot, 'src'), path.join(packageRoot, 'node_modules')],
             use: [babelLoader(babelEnv)],
           },

--- a/packages/one-app-bundler/webpack/module/webpack.server.js
+++ b/packages/one-app-bundler/webpack/module/webpack.server.js
@@ -44,12 +44,12 @@ module.exports = extendWebpackConfig(merge(
     resolve: {
       mainFields: ['module', 'main'],
       modules: [packageRoot, 'node_modules'],
-      extensions: ['.js', '.jsx'],
+      extensions: ['.js', '.jsx', '.ts', '.tsx'],
     },
     module: {
       rules: [
         {
-          test: /\.jsx?$/,
+          test: /\.[jt]sx?$/,
           include: [path.join(packageRoot, 'src'), path.join(packageRoot, 'node_modules')],
           use: [babelLoader()],
         },

--- a/packages/one-app-bundler/webpack/webpack.common.js
+++ b/packages/one-app-bundler/webpack/webpack.common.js
@@ -45,7 +45,7 @@ module.exports = {
     minimize: nodeEnvironmentIsProduction,
     minimizer: [
       new TerserPlugin({
-        test: /\.jsx?$/i,
+        test: /\.[jt]sx?$/i,
         extractComments: false,
         terserOptions: {
           compress: {
@@ -77,7 +77,7 @@ module.exports = {
       },
       {
         enforce: 'pre',
-        test: /\.jsx?$/,
+        test: /\.[jt]sx?$/,
         exclude: /node_modules/,
         loader: 'eslint-loader',
         options: {

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader.spec.js
@@ -110,7 +110,7 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
           mockFileContent,
         });
 
-        expect(loader).toEqual('jsx');
+        expect(loader).toEqual('tsx');
         expect(contents).toEqual(fs.readFileSync(`${__dirname}/__test_fixtures__/one-app-index-loader/index_browser-not-watching.output.jsx`).toString());
       });
 
@@ -128,7 +128,7 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
           mockFileContent,
         });
 
-        expect(loader).toEqual('jsx');
+        expect(loader).toEqual('tsx');
         expect(contents).toEqual(fs.readFileSync(`${__dirname}/__test_fixtures__/one-app-index-loader/index_browser-watching-not-live.output.jsx`).toString());
       });
 
@@ -146,7 +146,7 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
           mockFileContent,
         });
 
-        expect(loader).toEqual('jsx');
+        expect(loader).toEqual('tsx');
         expect(contents).toEqual(fs.readFileSync(`${__dirname}/__test_fixtures__/one-app-index-loader/index_browser-watching-live.output.jsx`).toString());
       });
 
@@ -164,7 +164,7 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
           mockFileContent,
         });
 
-        expect(loader).toEqual('jsx');
+        expect(loader).toEqual('tsx');
         expect(contents).toEqual(fs.readFileSync(`${__dirname}/__test_fixtures__/one-app-index-loader/index_server-not-watching.output.jsx`).toString());
       });
 
@@ -182,7 +182,7 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
           mockFileContent,
         });
 
-        expect(loader).toEqual('jsx');
+        expect(loader).toEqual('tsx');
         expect(contents).toEqual(fs.readFileSync(`${__dirname}/__test_fixtures__/one-app-index-loader/index_server-watching-not-live.output.jsx`).toString());
       });
 
@@ -200,7 +200,7 @@ describe('Esbuild plugin oneAppIndexLoader', () => {
           mockFileContent,
         });
 
-        expect(loader).toEqual('jsx');
+        expect(loader).toEqual('tsx');
         expect(contents).toEqual(fs.readFileSync(`${__dirname}/__test_fixtures__/one-app-index-loader/index_server-watching-live.output.jsx`).toString());
       });
     });

--- a/packages/one-app-dev-bundler/esbuild/plugins/one-app-index-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/one-app-index-loader.js
@@ -82,7 +82,7 @@ const oneAppIndexLoader = (options) => ({
 
       return {
         contents: outputContent,
-        loader: 'jsx', // for the live module container
+        loader: 'tsx', // for the live module container
       };
     });
   },


### PR DESCRIPTION
## **Description**
Allow the bundlers to consume TS. They do not 'handle' TS, they just compile it away. Consumers should setup their own typescript configs

## **Motivation** 
This allows code to be written in TS with no addition compilation steps prior to calling `bundle-module`

## **Test** **Conditions**
Unit tests

## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
