### PR TITLE
fix(one-app-runner-test): improve console messaging

### DIFF
--- a/packages/one-app-runner/bin/one-app-runner-test.js
+++ b/packages/one-app-runner/bin/one-app-runner-test.js
@@ -25,7 +25,7 @@ const run = async () => {
   const port = process.env.HTTP_PORT;
   const timeout = 200000;
 
-  console.log(`Waiting for one app to start on port ${port}`);
+  console.log(`Waiting for One App to start on port ${port}`);
 
   const resolvedStatus = await waitForOK({
     url: `http://localhost:${port}/_/status`,
@@ -33,9 +33,9 @@ const run = async () => {
   });
 
   if (resolvedStatus) {
-    console.log(`One app server started successfully on port ${port}`);
+    console.log(`One App server started successfully on port ${port}`);
   } else {
-    console.error(`One app crashed in ${timeout}ms`);
+    console.error(`One App failed to start within ${timeout}ms. Please check the one-app-test.log for more information.`);
     process.exit(1);
   }
 };


### PR DESCRIPTION
## **Description**
Closes #524 

## **Motivation** 
The console messaging did not use proper One App product names and was inaccurate in the case where the server did not startup.

New output:
```
Waiting for One App to start on port 51954
One App failed to start within 200000ms. Please check the one-app-test.log for more information.
```

## **Test** **Conditions**
Ran `yarn pack` and then installed the resulting package to a module.  Changed the module map to be incorrect and ran `one-app-runner-test` and produced expected output.

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
