### PR TITLE
fix(dev-bundler): improve error when NODE_ENV not development

### DIFF
--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/prevent-prod-builds-for-now.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/prevent-prod-builds-for-now.spec.js
@@ -59,7 +59,9 @@ describe('Esbuild plugin preventProdBuildsForNow', () => {
  ____) |  | | | |__| | |     
 |_____/   |_|  \\____/|_|     
 
-This bundler is only enabled for local development. If you see this message please raise an issue`);
+This bundler is only enabled for local development.
+
+NODE_ENV variable is set to 'production' but must be set to 'development'.`);
       expect(process.exit).toHaveBeenCalledTimes(1);
       expect(process.exit).toHaveBeenCalledWith(2);
     });

--- a/packages/one-app-dev-bundler/esbuild/plugins/prevent-prod-builds-for-now.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/prevent-prod-builds-for-now.js
@@ -26,7 +26,9 @@ const preventProdBuildsForNow = {
  ____) |  | | | |__| | |     
 |_____/   |_|  \\____/|_|     
 
-This bundler is only enabled for local development. If you see this message please raise an issue`);
+This bundler is only enabled for local development.
+
+NODE_ENV variable is set to '${process.env.NODE_ENV}' but must be set to 'development'.`);
       // eslint-disable-next-line unicorn/no-process-exit -- This is a cli app.
       process.exit(2);
     }


### PR DESCRIPTION
## **Description**
Closes #527 

## **Motivation** 
Changes the message when NODE_ENV != 'development' to be more descriptive, and not to suggest reporting an issue.

```
      _____ _______ ____  _____  
     / ____|__   __/ __ \|  __ \ 
    | (___    | | | |  | | |__) |
     \___ \   | | | |  | |  ___/ 
     ____) |  | | | |__| | |     
    |_____/   |_|  \____/|_|     
    
    This bundler is only enabled for local development.
    
    NODE_ENV variable is set to 'production' but must be set to 'development'.
```
The other case where it is not set at all:
```
NODE_ENV variable is set to 'undefined' but must be set to 'development'.
```

Old message:
```
This bundler is only enabled for local development. If you see this message please raise an issue
```

## **Test** **Conditions**
Updated unit tests.
Ran `yarn pack` and installed in a module and validated updated message was shown.

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
