### PR TITLE
chore(docs): add release doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,18 +38,6 @@ This project adheres to the American Express [Code of Conduct](./CODE_OF_CONDUCT
 
 4. You can now run the scripts within the different [packages](./packages).
 
-### Creating a `one-app-cli` new release
-
-1. Create, checkout and push a new release branch
-2. Run `yarn lerna:version` locally from your release branch. This will push your release changes(changelog and tags) to the branch on github.
-3. Ensure that correctly formatted tags have been created for each package being versioned. Tag needs to be in the format of `@americanexpress/[package-name]@x.x.x` for example`@americanexpress/one-app-bundler@6.0.0`. This can impact future releases.
-4. Create a pull request from your branch to the `main` branch with your changes.
-5. When merging try to ensure that commit does not get squashed as this will cause the tags be against missing commits.
-6. Once merged run the [manually publish](https://github.com/americanexpress/one-app-cli/actions/workflows/publish.yml) github action workflow.
-
-One App Cli is currently not setup for pre-releases.
-In theory, if one is required, using [--conventional-prerelease](https://github.com/lerna/lerna/tree/main/commands/version#--conventional-prerelease) in step two should work. For example: `yarn lerna:version --conventional-prerelease`
-
 ## Submitting a new feature
 
 When submitting a new feature request or enhancement of an existing features please review the following:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+# Creating a `one-app-cli` new release
+
+1. Create, checkout and push a new release branch
+2. Fetch tags `git fetch --tags`
+3. Run `yarn lerna:version` locally from your release branch. This will push your release changes(changelog and tags) to the branch on github.
+4. Ensure that correctly formatted tags have been created for each package being versioned. Tag needs to be in the format of `@americanexpress/[package-name]@x.x.x` for example`@americanexpress/one-app-bundler@6.0.0`. This can impact future releases.
+5. Create a pull request from your branch to the `main` branch with your changes.
+6. When merging try to ensure that commit does not get squashed as this will cause the tags be against missing commits.
+7. Once merged run the [manually publish](https://github.com/americanexpress/one-app-cli/actions/workflows/publish.yml) github action workflow.
+
+One App Cli is currently not setup for pre-releases.
+In theory, if one is required, using [--conventional-prerelease](https://github.com/lerna/lerna/tree/main/commands/version#--conventional-prerelease) in step two should work. For example: `yarn lerna:version --conventional-prerelease`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,5 +8,5 @@
 6. When merging try to ensure that commit does not get squashed as this will cause the tags be against missing commits.
 7. Once merged run the [manually publish](https://github.com/americanexpress/one-app-cli/actions/workflows/publish.yml) github action workflow.
 
-One App Cli is currently not setup for pre-releases.
+One App CLI is currently not setup for pre-releases.
 In theory, if one is required, using [--conventional-prerelease](https://github.com/lerna/lerna/tree/main/commands/version#--conventional-prerelease) in step two should work. For example: `yarn lerna:version --conventional-prerelease`


### PR DESCRIPTION
create a new RELEASE doc to make it clear where the release instructions are.

Added a new step to the release process, which is to fetch tags before starting the release.
Not doing so has caused issues in the past.