### PR TITLE
feat(devBundler): aggregate styles into dependencies and local overrides

### DIFF
--- a/jest.esm.config.js
+++ b/jest.esm.config.js
@@ -28,6 +28,7 @@ module.exports = {
     '!**/node_modules/**',
     '!**/build/**',
     '!packages/*/test-results/**',
+    '!packages/*/jest.esm.setup.js',
     // Despite it not being in the root, coverage reports see this package
     '!packages/one-app-locale-bundler/**',
   ],

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader-injectors/output-tests/dev-live-reloader-injector_output.spec.jsx
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/one-app-index-loader-injectors/output-tests/dev-live-reloader-injector_output.spec.jsx
@@ -157,7 +157,6 @@ describe('the output from dev-websocket-injector', () => {
       'Watch Client 51993 | Connected',
       'Watch Server | Reload clients',
       'Watch Client 51993 | Successfully reloaded mock-module-name',
-      'Watch Client 51993 | Connected',
     ]);
   });
 });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/server-styles-dispatcher.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/server-styles-dispatcher.spec.js
@@ -45,7 +45,7 @@ describe('server styles dispatcher', () => {
         serverStylesDispatcher({ bundleType: BUNDLE_TYPES.SERVER })
       );
       const onEnd = hooks.onEnd[0];
-      addStyle('body{background: white;}body > p{font-color: black;}');
+      addStyle('digestMock', 'body{background: white;}body > p{font-color: black;}');
 
       /* onEnd test start */
       // mock the bundle using mockFs
@@ -64,7 +64,10 @@ describe('server styles dispatcher', () => {
       expect(actualBundleContent).toMatchInlineSnapshot(`
 "const mock = \\"JavaScript Content\\";
     ;module.exports.ssrStyles = {
-      getFullSheet: () => \\"body{background: white;}body > p{font-color: black;}\\",
+      aggregatedStyles: [{\\"css\\":\\"body{background: white;}body > p{font-color: black;}\\",\\"digest\\":\\"digestMock\\"}],
+      getFullSheet: function getFullSheet() {
+  return this.aggregatedStyles.reduce((acc, { css }) => acc + css, '');
+},
     };"
 `);
 

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/styles-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/styles-loader.spec.js
@@ -107,7 +107,7 @@ describe('Esbuild plugin stylesLoader', () => {
 
           expect(loader).toEqual('js');
           expect(contents).toMatchInlineSnapshot(`
-"const digest = 'c0c0c0be320475d1514fe8e0c023d2780b6e23c2adab14a438a0ee2ef98369ba';
+"const digest = '5e9583e668d7632ccabf75f612a320b29f5f48cd7a7e86489c7b0f8f5fdcdbbe';
 const css = \`body {
   background: white;
 }
@@ -152,7 +152,7 @@ body > p {
           expect(sassCompile).toHaveBeenCalledTimes(0);
           expect(loader).toEqual('js');
           expect(contents).toMatchInlineSnapshot(`
-"const digest = '83279c4025e8b1107c3f376acaaac5656a3b68d0066ab70f2ceeb3c065a5751f';
+"const digest = '5e9583e668d7632ccabf75f612a320b29f5f48cd7a7e86489c7b0f8f5fdcdbbe';
 const css = \`body {
   background: white;
 }
@@ -200,7 +200,7 @@ body > p {
 
         expect(loader).toEqual('js');
         expect(contents).toMatchInlineSnapshot(`
-"const digest = 'c0c0c0be320475d1514fe8e0c023d2780b6e23c2adab14a438a0ee2ef98369ba';
+"const digest = '11e1fda0219a10c2de0ad6b28c1c6519985965cbef3f5b8f8f119d16f1bafff3';
 const css = \`body {
   background: white;
 }
@@ -239,7 +239,7 @@ body > p {
         expect(sassCompile).toHaveBeenCalledTimes(0);
         expect(loader).toEqual('js');
         expect(contents).toMatchInlineSnapshot(`
-"const digest = '83279c4025e8b1107c3f376acaaac5656a3b68d0066ab70f2ceeb3c065a5751f';
+"const digest = '5e9583e668d7632ccabf75f612a320b29f5f48cd7a7e86489c7b0f8f5fdcdbbe';
 const css = \`body {
   background: white;
 }
@@ -306,7 +306,7 @@ export { css, digest };"
         expect(sassCompile).toHaveBeenCalledTimes(0);
         expect(loader).toEqual('js');
         expect(contents).toMatchInlineSnapshot(`
-"const digest = '786f696ae19422021e0f17df7c6dd6eb43f92c9c101f7d0649b341165dda1b31';
+"const digest = 'f85b3a3cf0c00eb3fd23e6d440b10077d7493cf7f127538acb994cade5bce451';
 const css = \`              ._root_1vf0l_1 {
                 background: white;
               }
@@ -378,7 +378,7 @@ export { css, digest };"
         expect(sassCompile).toHaveBeenCalledTimes(0);
         expect(loader).toEqual('js');
         expect(contents).toMatchInlineSnapshot(`
-"const digest = '786f696ae19422021e0f17df7c6dd6eb43f92c9c101f7d0649b341165dda1b31';
+"const digest = 'f85b3a3cf0c00eb3fd23e6d440b10077d7493cf7f127538acb994cade5bce451';
 const css = \`              ._root_1vf0l_1 {
                 background: white;
               }
@@ -432,7 +432,7 @@ export { css, digest };"
 
         expect(loader).toEqual('js');
         expect(contents).toMatchInlineSnapshot(`
-"const digest = 'c0c0c0be320475d1514fe8e0c023d2780b6e23c2adab14a438a0ee2ef98369ba';
+"const digest = '5e9583e668d7632ccabf75f612a320b29f5f48cd7a7e86489c7b0f8f5fdcdbbe';
 const css = \`body {
   background: white;
 }
@@ -481,7 +481,7 @@ body > p {
         expect(sassCompile).toHaveBeenCalledTimes(0);
         expect(loader).toEqual('js');
         expect(contents).toMatchInlineSnapshot(`
-"const digest = '83279c4025e8b1107c3f376acaaac5656a3b68d0066ab70f2ceeb3c065a5751f';
+"const digest = '5e9583e668d7632ccabf75f612a320b29f5f48cd7a7e86489c7b0f8f5fdcdbbe';
 const css = \`body {
   background: white;
 }

--- a/packages/one-app-dev-bundler/__tests__/esbuild/utils/server-style-aggregator.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/utils/server-style-aggregator.spec.js
@@ -14,30 +14,50 @@
  * permissions and limitations under the License.
  */
 
-import { getAggregatedStyles, emptyAggregatedStyles, addStyle } from '../../../esbuild/utils/server-style-aggregator';
+import {
+  getAggregatedStyles,
+  emptyAggregatedStyles,
+  addStyle,
+} from '../../../esbuild/utils/server-style-aggregator';
 
-describe('serverSideAggirgator utilities', () => {
+describe('serverSideAggregatorStyles utilities', () => {
   beforeEach(() => {
     emptyAggregatedStyles();
-    jest.clearAllMocks();
   });
 
   describe('addStyle', () => {
-    it('should append given perameter to aggregatedStyles', () => {
-      addStyle('testing string');
-      expect(getAggregatedStyles()).toBe('testing string');
+    it('should append styles to the aggregatedStyles as an object with a digest and css key', () => {
+      addStyle('digestMock', 'cssMock', false);
+      expect(getAggregatedStyles()).toBe('[{"css":"cssMock","digest":"digestMock"}]');
+    });
+
+    it('should deduplicate styles added that share the same digest', () => {
+      addStyle('digestMock', 'cssMock', false);
+      addStyle('digestMock', 'cssMock', false);
+      addStyle('digestMock', 'cssMock', false);
+      addStyle('digestMock', 'cssMock', false);
+      expect(getAggregatedStyles()).toBe('[{"css":"cssMock","digest":"digestMock"}]');
     });
   });
-  describe('getAggrigatedStyles', () => {
-    it('should return string of any and all collected styles', () => {
-      expect(getAggregatedStyles()).toBe('');
+
+  describe('getAggregatedStyles', () => {
+    it('should return a stringified empty array when no styles have been added', () => {
+      expect(getAggregatedStyles()).toBe('[]');
+    });
+
+    it('should return a stringified array with dependency styles declared first and local styles declared last', () => {
+      addStyle('digestLocalMock', 'cssLocalMock', false);
+      addStyle('digestDepsMock', 'cssDepsMock', true);
+      expect(getAggregatedStyles()).toBe('[{"css":"cssDepsMock","digest":"digestDepsMock"},{"css":"cssLocalMock","digest":"digestLocalMock"}]');
     });
   });
-  describe('emptyAggrigatedStyles', () => {
+
+  describe('emptyAggregatedStyles', () => {
     it('should return emptied string', () => {
-      addStyle('testing string');
+      addStyle('digestMock', 'cssMock', false);
+      expect(getAggregatedStyles()).toBe('[{"css":"cssMock","digest":"digestMock"}]');
       emptyAggregatedStyles();
-      expect(getAggregatedStyles()).toBe('');
+      expect(getAggregatedStyles()).toBe('[]');
     });
   });
 });

--- a/packages/one-app-dev-bundler/esbuild/plugins/server-styles-dispatcher.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/server-styles-dispatcher.js
@@ -32,7 +32,10 @@ const serverStylesDispatcher = ({ bundleType }) => ({
           const initialContent = await fs.promises.readFile(fileName, 'utf8');
           const outputContent = `${initialContent}
     ;module.exports.ssrStyles = {
-      getFullSheet: () => ${JSON.stringify(getAggregatedStyles())},
+      aggregatedStyles: ${getAggregatedStyles()},
+      getFullSheet: function getFullSheet() {
+  return this.aggregatedStyles.reduce((acc, { css }) => acc + css, '');
+},
     };`;
           await fs.promises.writeFile(fileName, outputContent, 'utf8');
         }));

--- a/packages/one-app-dev-bundler/esbuild/plugins/styles-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/styles-loader.js
@@ -67,7 +67,7 @@ const stylesLoader = (cssModulesOptions = {}, { bundleType } = {}) => ({
       });
 
       const hash = crypto.createHash('sha256');
-      hash.update(args.path);
+      hash.update(result.css);
       const digest = hash.copy().digest('hex');
 
       let injectedCode = '';
@@ -84,7 +84,8 @@ const stylesLoader = (cssModulesOptions = {}, { bundleType } = {}) => ({
 })();`;
       } else {
         // For SSR, aggregate all styles, then inject them once at the end
-        addStyle(result.css);
+        const isDependencyFile = args.path.indexOf('/node_modules/') >= 0;
+        addStyle(digest, result.css, isDependencyFile);
       }
 
       // provide useful values to the importer of this file, most importantly, the classnames

--- a/packages/one-app-dev-bundler/esbuild/utils/server-style-aggregator.js
+++ b/packages/one-app-dev-bundler/esbuild/utils/server-style-aggregator.js
@@ -14,14 +14,36 @@
  * permissions and limitations under the License.
  */
 
-let aggregatedStyles = '';
+let aggregatedStyles = {
+  deps: [],
+  local: [],
+};
 
-export function addStyle(style) {
-  aggregatedStyles += style;
+let sheetDigests = new Set();
+
+export function addStyle(digest, css, isDependencyFile) {
+  if (!sheetDigests.has(digest)) {
+    sheetDigests.add(digest);
+
+    aggregatedStyles[isDependencyFile ? 'deps' : 'local'].push({
+      css,
+      digest,
+    });
+  }
 }
 
-export const getAggregatedStyles = () => aggregatedStyles;
+/**
+ * Returns aggregated styles object from all parsed CSS files
+ * @returns {{deps: *[{css: string, digest: string}], local: *[{css: string, digest: string}]}}
+ */
+export const getAggregatedStyles = () => JSON.stringify(
+  [...aggregatedStyles.deps, ...aggregatedStyles.local]
+);
 
 export function emptyAggregatedStyles() {
-  aggregatedStyles = '';
+  aggregatedStyles = {
+    deps: [],
+    local: [],
+  };
+  sheetDigests = new Set();
 }

--- a/packages/one-app-dev-bundler/jest.config.cjs
+++ b/packages/one-app-dev-bundler/jest.config.cjs
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+const jestConfig = require('../../jest.esm.config');
+
+module.exports = {
+  ...jestConfig,
+  collectCoverageFrom: [
+    ...jestConfig.collectCoverageFrom,
+    '**/*.{mjs,js,jsx}',
+  ],
+  roots: ['./']
+};

--- a/packages/one-app-dev-bundler/jest.esm.setup.js
+++ b/packages/one-app-dev-bundler/jest.esm.setup.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+const jestSetup = require('../../jest.esm.setup');
+
+module.exports = jestSetup;


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_

This PR achieves two primary features:

- It aggregates S/CSS files to allow for dependencies to be loaded first, with local application overrides applying last. When rendered into the DOM, this means that application styles that override component library styles don't need to fight for specificity because they will naturally appear last in the cascade.
- It adjusts the file hash to use the file contents, rather than the file absolute path. This allows files to be deduplicated if they are being rendered into the page, particularly for styles loaded from dependencies such as component libraries, because the file contents will be the same between modules, even when the absolute path is not.

Coupled with an adjustment to the OneApp style loader, this will allow styles to be rendered into the page consistently between Client and Server renders, remove an unnecessary style recalculation step from the browser, and remove duplicated styles being rendered onto the page for each module.

## **Motivation** 
#### _Why is this change required? What issue does it resolve?_

Currently when bundling a OneApp module, the styles are added to the page inconsistently between the server and client side bundles. The server bundle adds the styles "upside down" with local application styles appearing first, and dependency styles appearing last.

In addition, once the client bundle has hydrated the styles to the expected order, duplicate style tags are rendered multiple times, resulting in local application styles being ignored.

## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 

Tested running a root module with three child modules each serving a shared dependency component library. Each module renders a component twice. Once with no changes, and once with style overrides local to the module.

The expected output is three modules, showing a green component, and then a blue/red component with text that has an orange background color.

The expected DOM output was three style tags, one with the styles for the shared component (deduplicated twice), one with the styles for the blue override (deduplicated once between Module One and Two), and one with the styles for the red override.

<img width="933" alt="Screenshot 2023-08-29 at 16 10 37" src="https://github.com/americanexpress/one-app-cli/assets/9933592/571980ea-c465-465d-8148-4c2a39736409">
<img width="710" alt="Screenshot 2023-08-29 at 22 30 17" src="https://github.com/americanexpress/one-app-cli/assets/9933592/0aa9354c-454a-472d-85ed-bcb9b01fc435">

For backwards compatibility, a getFullSheet function is included that returns a single string of all the aggregated styles as a string. This allows for running an updated bundle in a version of OneApp that doesn't support the style aggregation.

To note - this getFullSheet does correctly organise the styles to put dependencies before local overrides, which would partially solve the problem where styles are inconsistent between SSR and CSR, so even in an older version of OneApp, a modern bundle would result in more consistency when hydrated.

## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [x] I have added the Apache 2.0 license header to any new files created.
