### PR TITLE
fix(devBundler): check for Holocron.getExternal

### DIFF
--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/externals-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/externals-loader.spec.js
@@ -107,7 +107,7 @@ describe('Esbuild plugin externalsLoader', () => {
 "
           try {
             const Holocron = globalThis.Holocron;
-            const fallbackExternal = Holocron.getExternal({
+            const fallbackExternal = Holocron.getExternal && Holocron.getExternal({
               name: 'mock/path/to/file/mock-package-name',
               version: 'undefined'
             });
@@ -148,7 +148,7 @@ describe('Esbuild plugin externalsLoader', () => {
 "
           try {
             const Holocron = require(\\"holocron\\");
-            const fallbackExternal = Holocron.getExternal({
+            const fallbackExternal = Holocron.getExternal && Holocron.getExternal({
               name: 'mock/path/to/file/mock-package-name',
               version: 'undefined'
             });

--- a/packages/one-app-dev-bundler/esbuild/plugins/externals-loader.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/externals-loader.js
@@ -65,7 +65,7 @@ const externalsLoader = ({ bundleType }) => ({
         contents: `
           try {
             const Holocron = ${bundleType === BUNDLE_TYPES.SERVER ? 'require("holocron")' : `${globalReferenceString}.Holocron`};
-            const fallbackExternal = Holocron.getExternal({
+            const fallbackExternal = Holocron.getExternal && Holocron.getExternal({
               name: '${externalName}',
               version: '${version}'
             });


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**

On one-app v5, modules will fail to load because `Holocron.getExternal` does not exist.

We also do this check in the prod-bundler, so better to keep consistency with the prod bundler.



## **Motivation** 
This was causing modules to fail to load when build with the dev-bundler locally.

## **Test** **Conditions**

modified the bundler of a module to include these changes, and it loaded without issue


## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
