### PR TITLE
chore(workflows): use GITHUB_OUTPUT instead of ::set-output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
     - id: commit
-      run: echo "::set-output name=message::${{ github.event.head_commit.message }}"
+      run: echo "message=${{ github.event.head_commit.message }}" >> $GITHUB_OUTPUT
     outputs:
       commitMsg: ${{ steps.commit.outputs.message }}
   publish:


### PR DESCRIPTION

#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_


#### _This project only accepts pull requests related to open issues._
#### _If suggesting a new feature or change, please discuss it in an issue first._


<!--- Describe your changes in detail -->
replace
```shell
echo "::set-output name={name}::{value}"
```
with
```shell
echo "{name}={value}" >> $GITHUB_OUTPUT
```

## **Motivation** 
#### _Why is this change required? What issue does it resolve?_
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
these are now showing as warnings in the runs, e.g. https://github.com/americanexpress/one-app/actions/runs/6344142425

## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 
https://github.com/americanexpress/one-app/pull/1141

## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [x] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
