### PR TITLE
Feature/mount user one app directory

### DIFF
--- a/packages/one-app-runner/__tests__/src/startApp.spec.js
+++ b/packages/one-app-runner/__tests__/src/startApp.spec.js
@@ -372,7 +372,7 @@ describe('startApp', () => {
     );
   });
 
-  it('ensures the user\s One App directory exists', async () => {
+  it('ensures the user\'s One App directory exists', async () => {
     expect.assertions(1);
 
     const mockSpawn = makeMockSpawn();
@@ -386,7 +386,7 @@ describe('startApp', () => {
     expect(fs.promises.mkdir.mock.calls[0]).toEqual(['/home/user/.one-app']);
   });
 
-  it('mounts the user\s One App directory', async () => {
+  it('mounts the user\'s One App directory', async () => {
     expect.assertions(1);
 
     const mockSpawn = makeMockSpawn();
@@ -402,7 +402,7 @@ describe('startApp', () => {
     ]);
   });
 
-  it('shows a warning when there was an error creating the user\s One App directory', async () => {
+  it('shows a warning when there was an error creating the user\'s One App directory', async () => {
     expect.assertions(2);
 
     const mockSpawn = makeMockSpawn();
@@ -432,7 +432,7 @@ describe('startApp', () => {
     `);
   });
 
-  it('does not mount the user\s One App directory when there was an error creating it', async () => {
+  it('does not mount the user\'s One App directory when there was an error creating it', async () => {
     expect.assertions(1);
 
     const mockSpawn = makeMockSpawn();
@@ -456,7 +456,7 @@ describe('startApp', () => {
     expect(mockSpawn.calls[1].args.filter((arg) => arg.startsWith('-v=/home/user/.one-app'))).toEqual([]);
   });
 
-  it('does not show a warning when the user\s One App directory already exists', async () => {
+  it('does not show a warning when the user\'s One App directory already exists', async () => {
     expect.assertions(1);
 
     const mockSpawn = makeMockSpawn();
@@ -481,7 +481,7 @@ describe('startApp', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  it('mounts the user\s One App directory when it already exists', async () => {
+  it('mounts the user\'s One App directory when it already exists', async () => {
     expect.assertions(1);
 
     const mockSpawn = makeMockSpawn();


### PR DESCRIPTION
## **Description**
builds on #569 to avoid conflicts and refactoring
https://github.com/americanexpress/one-app-cli/compare/fix/runner-avoid-shell...feature/mount-user-one-app-directory?expand=1#diff

adds support for cached modules (https://github.com/americanexpress/one-app/pull/1094) to the runner


## **Motivation** 
> This feature helps to cache CDN modules in users machine. It helps to start application faster locally.


## **Test** **Conditions**
unit tests, `$ npm pack`'d and ran in a module

## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
