### PR TITLE
fix(one-app-runner): suppress npm update notifications

### DIFF
--- a/packages/one-app-runner/__tests__/src/startApp.spec.js
+++ b/packages/one-app-runner/__tests__/src/startApp.spec.js
@@ -78,7 +78,7 @@ describe('startApp', () => {
         "one-app:5.0.0",
         "/bin/sh",
         "-c",
-        "   node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  ",
+        "npm config set update-notifier false &&    node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  ",
       ]
     `);
   });
@@ -139,7 +139,7 @@ describe('startApp', () => {
       '-v=/home/user/.one-app:/home/node/.one-app',
     ]);
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot(
-      '"npm run serve-module \'/opt/module-workspace/module-a\' &&npm run serve-module \'/opt/module-workspace/to-module-b\' &&   node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "'
+      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&npm run serve-module \'/opt/module-workspace/to-module-b\' &&   node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "'
     );
   });
 
@@ -156,7 +156,7 @@ describe('startApp', () => {
       '-v=/home/user/.one-app:/home/node/.one-app',
     ]);
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot(
-      '"npm run serve-module \'/opt/module-workspace/module-a\' &&npm run serve-module \'/opt/module-workspace/to-module-b\' &&   node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root   "'
+      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&npm run serve-module \'/opt/module-workspace/to-module-b\' &&   node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root   "'
     );
   });
 
@@ -168,7 +168,7 @@ describe('startApp', () => {
       moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], parrotMiddlewareFile: '/path/to/module-a/dev.middleware.js',
     });
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot(
-      '"npm run serve-module \'/opt/module-workspace/module-a\' && npm run set-middleware \'/opt/module-workspace/module-a/dev.middleware.js\' &&  node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json -m "'
+      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' && npm run set-middleware \'/opt/module-workspace/module-a/dev.middleware.js\' &&  node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json -m "'
     );
   });
 
@@ -180,7 +180,7 @@ describe('startApp', () => {
       moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], devEndpointsFile: '/path/to/module-a/dev.endpoints.js',
     });
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot(
-      '"npm run serve-module \'/opt/module-workspace/module-a\' &&  npm run set-dev-endpoints \'/opt/module-workspace/module-a/dev.endpoints.js\' && node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "'
+      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&  npm run set-dev-endpoints \'/opt/module-workspace/module-a/dev.endpoints.js\' && node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "'
     );
   });
 
@@ -344,6 +344,18 @@ describe('startApp', () => {
       '-v=/envVar/location/cert.pem:/opt/certs.pem',
       '-v=/home/user/.one-app:/home/node/.one-app',
     ]);
+  });
+
+  it('suppresses npm update notifications', async () => {
+    expect.assertions(1);
+    const mockSpawn = makeMockSpawn();
+    childProcess.spawn.mockImplementation(mockSpawn);
+    await startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], dockerNetworkToJoin: 'one-test-environment-1234',
+    });
+    expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatch(
+      'npm config set update-notifier false'
+    );
   });
 
   it('applies inspect mode to node process when useDebug is passed', async () => {

--- a/packages/one-app-runner/src/startApp.js
+++ b/packages/one-app-runner/src/startApp.js
@@ -110,6 +110,8 @@ const generateSetDevEndpointsCommand = (pathToDevEndpointsFile) => {
 
 const generateUseMocksFlag = (shouldUseMocks) => (shouldUseMocks ? '-m' : '');
 
+const generateNpmConfigCommands = () => 'npm config set update-notifier false &&';
+
 const generateServeModuleCommands = (modules) => {
   let command = '';
   if (modules && modules.length > 0) {
@@ -190,6 +192,8 @@ module.exports = async function startApp({
   }
 
   const containerShellCommand = `${
+    generateNpmConfigCommands()
+  } ${
     generateServeModuleCommands(modulesToServe)
   } ${
     generateSetMiddlewareCommand(parrotMiddlewareFile)


### PR DESCRIPTION
## **Description**

Set `update-notifier` to false before running any `npm` commands.  This avoids printing a notification that npm has an update available on every one-app start.

## **Motivation** 
Fixes #588

I used the top-voted solution on this question:
https://stackoverflow.com/questions/46800717/eliminate-npm-update-available-message

The other options seemed either undocumented or needed to be used on the first `npm` command which is more complicated since the commands are dynamically geneated.

## **Test** **Conditions**
Ran `yarn pack` and then installed the `one-app-runner` package in my module.  Verified that npm update notification was no longer showing.

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
