### PR TITLE
fix(one-app-bundler): packages don't include package.json in exports

### DIFF
--- a/packages/one-app-bundler/__tests__/webpack/loaders/externals-loader.spec.js
+++ b/packages/one-app-bundler/__tests__/webpack/loaders/externals-loader.spec.js
@@ -25,9 +25,12 @@ jest.mock('loader-utils', () => ({
 jest.mock('read-pkg-up', () => ({
   sync: () => ({
     packageJson: {
+      // this is used for the first call for modules package.json
       dependencies: {
         'my-dependency': '^1.0.0',
       },
+      // this is used on second call for the dependency package.json
+      version: '1.2.3',
     },
   }),
 }));

--- a/packages/one-app-bundler/webpack/loaders/externals-loader.js
+++ b/packages/one-app-bundler/webpack/loaders/externals-loader.js
@@ -13,13 +13,16 @@
  */
 const loaderUtils = require('loader-utils');
 const readPkgUp = require('read-pkg-up');
+const path = require('node:path');
 
 const { packageJson } = readPkgUp.sync();
 
 function externalsLoader() {
   const { externalName, bundleTarget } = loaderUtils.getOptions(this);
-  // eslint-disable-next-line global-require, import/no-dynamic-require -- need to require a package.json at runtime
-  const { version } = require(`${externalName}/package.json`);
+
+  const version = readPkgUp.sync({
+    cwd: path.resolve(process.cwd(), 'node_modules', externalName),
+  })?.packageJson.version;
 
   return `\
 try {


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_

A Holocron Modules Pure ESM depenencies may not include `package.json` in the exports list. Currently the bundler will fail for external deps with `Error: Package subpath './package.json' is not defined by "exports"`. This resolves the issue by not using `require` to load the dependencies package.json

## **Motivation** 
#### _Why is this change required? What issue does it resolve?_
Improve support for externalizing pure ESM dependencies 

## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 

Test suite. local test with a module which externlized a dependency which is ESM only. Started with failure case and after change build was able to complte successfully 

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
