### PR TITLE
fix(build-stats): esbuild and webpack stats under build-stats dir

### DIFF
--- a/packages/one-app-bundler/bin/postProcessOneAppBundle.js
+++ b/packages/one-app-bundler/bin/postProcessOneAppBundle.js
@@ -39,11 +39,14 @@ module.exports = async function postProcessBuild() {
   };
   const { hash } = await hashElement(tmpPath, options);
   const buildVersion = `${version}-${hash.slice(0, 8)}`;
-  if (!fs.existsSync(path.resolve(pkgPath, '../.build-stats'))) {
-    fs.mkdirSync(path.resolve(pkgPath, '../.build-stats'));
+
+  const buildStatsPath = path.resolve(pkgPath, '../.build-stats');
+
+  if (!fs.existsSync(buildStatsPath)) {
+    fs.mkdirSync(buildStatsPath);
   }
-  const modernBrowserChunkAssets = require(path.resolve(pkgPath, '../.build-stats/.webpack-stats.browser.json')).assetsByChunkName;
-  const legacyBrowserChunkAssets = require(path.resolve(pkgPath, '../.build-stats/.webpack-stats.legacyBrowser.json')).assetsByChunkName;
+  const modernBrowserChunkAssets = require(path.resolve(buildStatsPath, '.webpack-stats.browser.json')).assetsByChunkName;
+  const legacyBrowserChunkAssets = require(path.resolve(buildStatsPath, '.webpack-stats.legacyBrowser.json')).assetsByChunkName;
 
   fs.renameSync(tmpPath, path.resolve(tmpPath, `../${buildVersion}`));
   const metaFilePath = path.resolve(pkgPath, '../.build-meta.json');

--- a/packages/one-app-bundler/bin/postProcessOneAppBundle.js
+++ b/packages/one-app-bundler/bin/postProcessOneAppBundle.js
@@ -39,8 +39,11 @@ module.exports = async function postProcessBuild() {
   };
   const { hash } = await hashElement(tmpPath, options);
   const buildVersion = `${version}-${hash.slice(0, 8)}`;
-  const modernBrowserChunkAssets = require(path.resolve(pkgPath, '../.webpack-stats.browser.json')).assetsByChunkName;
-  const legacyBrowserChunkAssets = require(path.resolve(pkgPath, '../.webpack-stats.legacyBrowser.json')).assetsByChunkName;
+  if (!fs.existsSync(path.resolve(pkgPath, '../.build-stats'))) {
+    fs.mkdirSync(path.resolve(pkgPath, '../.build-stats'));
+  }
+  const modernBrowserChunkAssets = require(path.resolve(pkgPath, '../.build-stats/.webpack-stats.browser.json')).assetsByChunkName;
+  const legacyBrowserChunkAssets = require(path.resolve(pkgPath, '../.build-stats/.webpack-stats.legacyBrowser.json')).assetsByChunkName;
 
   fs.renameSync(tmpPath, path.resolve(tmpPath, `../${buildVersion}`));
   const metaFilePath = path.resolve(pkgPath, '../.build-meta.json');

--- a/packages/one-app-bundler/bin/webpackCallback.js
+++ b/packages/one-app-bundler/bin/webpackCallback.js
@@ -42,11 +42,12 @@ module.exports = function getWebpackCallback(label, isModuleBuild) {
       });
     }
 
-    if (!fs.existsSync(path.join(process.cwd(), '.build-stats'))) {
-      fs.mkdirSync(path.join(process.cwd(), '.build-stats'));
+    const buildStatsPath = path.join(process.cwd(), '.build-stats');
+    if (!fs.existsSync(buildStatsPath)) {
+      fs.mkdirSync(buildStatsPath);
     }
 
-    fs.writeFileSync(path.join(process.cwd(), '.build-stats', `.webpack-stats.${label}.json`), JSON.stringify(jsonStats));
+    fs.writeFileSync(path.join(buildStatsPath, `.webpack-stats.${label}.json`), JSON.stringify(jsonStats));
 
     if (isModuleBuild) {
       generateIntegrityManifest(

--- a/packages/one-app-bundler/bin/webpackCallback.js
+++ b/packages/one-app-bundler/bin/webpackCallback.js
@@ -42,7 +42,11 @@ module.exports = function getWebpackCallback(label, isModuleBuild) {
       });
     }
 
-    fs.writeFileSync(path.join(process.cwd(), `.webpack-stats.${label}.json`), JSON.stringify(jsonStats));
+    if (!fs.existsSync(path.join(process.cwd(), '.build-stats'))) {
+      fs.mkdirSync(path.join(process.cwd(), '.build-stats'));
+    }
+
+    fs.writeFileSync(path.join(process.cwd(), '.build-stats', `.webpack-stats.${label}.json`), JSON.stringify(jsonStats));
 
     if (isModuleBuild) {
       generateIntegrityManifest(

--- a/packages/one-app-dev-bundler/__tests__/utils/analyze-bundles.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/utils/analyze-bundles.spec.js
@@ -43,7 +43,7 @@ describe('analyze-bundles', () => {
     jest.clearAllMocks();
   });
 
-  it('reports the analysis comparting webpack vs esbuild', async () => {
+  it('reports the analysis comparing webpack vs esbuild', async () => {
     fs.promises.readFile.mockImplementation((absolutePath) => {
       const fileName = absolutePath.split(path.sep).reverse()[0];
 

--- a/packages/one-app-dev-bundler/esbuild/plugins/time-build.js
+++ b/packages/one-app-dev-bundler/esbuild/plugins/time-build.js
@@ -32,7 +32,10 @@ const timeBuild = ({ bundleName, watch }) => ({
       if (!watch) { // watch has its own logging
         console.log(`${bundleName} bundle built in ${result.durationMs}ms`);
         const sanitizedName = bundleName.replace('/', '-');
-        await fs.promises.writeFile(`.esbuild-stats.${sanitizedName}.json`, JSON.stringify({
+        if (!fs.existsSync('.build-stats')) {
+          await fs.promises.mkdir('.build-stats');
+        }
+        await fs.promises.writeFile(`./.build-stats/.esbuild-stats.${sanitizedName}.json`, JSON.stringify({
           ...result.metafile.outputs,
           durationMs: result.durationMs,
         }));

--- a/packages/one-app-dev-bundler/utils/analyze-bundles.js
+++ b/packages/one-app-dev-bundler/utils/analyze-bundles.js
@@ -25,7 +25,7 @@ const BUNDLERS = ['webpack', 'esbuild'];
 
 const readStatsFile = async (fileName) => {
   try {
-    const content = await fs.promises.readFile(path.resolve(process.cwd(), fileName), 'utf-8');
+    const content = await fs.promises.readFile(path.resolve(process.cwd(), '.build-stats', fileName), 'utf-8');
 
     return content;
   } catch (error) {


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_

This relocates all webpack and esbuild stat files under a `.build-stats` directory. 

Addressing https://github.com/americanexpress/one-app-cli/issues/592

#### _This project only accepts pull requests related to open issues._
#### _If suggesting a new feature or change, please discuss it in an issue first._


## **Motivation** 
#### _Why is this change required? What issue does it resolve?_

See issue https://github.com/americanexpress/one-app-cli/issues/592

## **Test** **Conditions**
#### _Describe in detail how the changes are tested._ 
#### _Include details of your testing environment, and the tests you ran to._
#### _How does your change affect the rest of the code._ 


## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
