### PR TITLE
fix: runner failed to start with node 12 images

### DIFF
--- a/packages/one-app-runner/__tests__/src/startApp.spec.js
+++ b/packages/one-app-runner/__tests__/src/startApp.spec.js
@@ -78,7 +78,7 @@ describe('startApp', () => {
         "one-app:5.0.0",
         "/bin/sh",
         "-c",
-        "npm config set update-notifier false &&    node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  ",
+        "npm config set update-notifier false &&    node   lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  ",
       ]
     `);
   });
@@ -139,7 +139,7 @@ describe('startApp', () => {
       '-v=/home/user/.one-app:/home/node/.one-app',
     ]);
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot(
-      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&npm run serve-module \'/opt/module-workspace/to-module-b\' &&   node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "'
+      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&npm run serve-module \'/opt/module-workspace/to-module-b\' &&   node   lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "'
     );
   });
 
@@ -156,7 +156,7 @@ describe('startApp', () => {
       '-v=/home/user/.one-app:/home/node/.one-app',
     ]);
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot(
-      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&npm run serve-module \'/opt/module-workspace/to-module-b\' &&   node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root   "'
+      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&npm run serve-module \'/opt/module-workspace/to-module-b\' &&   node   lib/server/index.js --root-module-name=frank-lloyd-root   "'
     );
   });
 
@@ -168,7 +168,7 @@ describe('startApp', () => {
       moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], parrotMiddlewareFile: '/path/to/module-a/dev.middleware.js',
     });
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot(
-      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' && npm run set-middleware \'/opt/module-workspace/module-a/dev.middleware.js\' &&  node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json -m "'
+      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' && npm run set-middleware \'/opt/module-workspace/module-a/dev.middleware.js\' &&  node   lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json -m "'
     );
   });
 
@@ -180,7 +180,7 @@ describe('startApp', () => {
       moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.0.0', modulesToServe: ['/path/to/module-a'], devEndpointsFile: '/path/to/module-a/dev.endpoints.js',
     });
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot(
-      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&  npm run set-dev-endpoints \'/opt/module-workspace/module-a/dev.endpoints.js\' && node --dns-result-order=ipv4first --no-experimental-fetch  lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "'
+      '"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&  npm run set-dev-endpoints \'/opt/module-workspace/module-a/dev.endpoints.js\' && node   lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "'
     );
   });
 
@@ -382,6 +382,38 @@ describe('startApp', () => {
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatch(
       '--inspect=0.0.0.0:9221'
     );
+  });
+
+  it('adds node flags when one-app version is greater than 5.13.0', async () => {
+    expect.assertions(1);
+    const mockSpawn = makeMockSpawn();
+    childProcess.spawn.mockImplementation(mockSpawn);
+    await startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.14.0', modulesToServe: ['/path/to/module-a'],
+    });
+    expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatch(
+      '--dns-result-order=ipv4first --no-experimental-fetch'
+    );
+  });
+  it('adds node flags when one-app version is greater than 5.13.0 but only major specified', async () => {
+    expect.assertions(1);
+    const mockSpawn = makeMockSpawn();
+    childProcess.spawn.mockImplementation(mockSpawn);
+    await startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5', modulesToServe: ['/path/to/module-a'],
+    });
+    expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatch(
+      '--dns-result-order=ipv4first --no-experimental-fetch'
+    );
+  });
+  it('does NOT add node flags when one-app version is less than 5.13.0', async () => {
+    expect.assertions(1);
+    const mockSpawn = makeMockSpawn();
+    childProcess.spawn.mockImplementation(mockSpawn);
+    await startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:5.12.0', modulesToServe: ['/path/to/module-a'],
+    });
+    expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatchInlineSnapshot('"npm config set update-notifier false && npm run serve-module \'/opt/module-workspace/module-a\' &&   node   lib/server/index.js --root-module-name=frank-lloyd-root --module-map-url=https://example.com/module-map.json  "');
   });
 
   it('ensures the user\'s One App directory exists', async () => {

--- a/packages/one-app-runner/src/startApp.js
+++ b/packages/one-app-runner/src/startApp.js
@@ -127,6 +127,21 @@ const generateModuleMap = (moduleMapUrl) => (moduleMapUrl ? `--module-map-url=${
 
 const generateDebug = (port, useDebug) => (useDebug ? `--inspect=0.0.0.0:${port}` : '');
 
+// Node 12 does not support --dns-result-order or --no-experimental-fetch
+// So we have to remove those flags if the one-app version is less than 5.13.0
+// 5.13.0 is when node 16 was introduced.
+const generateNodeFlags = (appVersion) => {
+  const versionArray = appVersion.split('.');
+  if (versionArray.length > 1) {
+    const majorVersion = Number.parseInt(versionArray[0], 10);
+    const minorVersion = Number.parseInt(versionArray[1], 10);
+    if (majorVersion === 5 && minorVersion < 13) {
+      return '';
+    }
+  }
+  return '--dns-result-order=ipv4first --no-experimental-fetch';
+};
+
 module.exports = async function startApp({
   moduleMapUrl,
   rootModuleName,
@@ -191,6 +206,8 @@ module.exports = async function startApp({
     containerEnvVars.set('NODE_EXTRA_CA_CERTS', mountPath);
   }
 
+  const appVersion = appDockerImage.split(':')[1];
+
   const containerShellCommand = `${
     generateNpmConfigCommands()
   } ${
@@ -199,7 +216,7 @@ module.exports = async function startApp({
     generateSetMiddlewareCommand(parrotMiddlewareFile)
   } ${
     generateSetDevEndpointsCommand(devEndpointsFile)
-  } node --dns-result-order=ipv4first --no-experimental-fetch ${
+  } node ${generateNodeFlags(appVersion)} ${
     generateDebug(debugPort, useDebug)
   } lib/server/index.js --root-module-name=${rootModuleName} ${
     generateModuleMap(moduleMapUrl)


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_
when an image provided to the one-app-runner is built with node 12, it would fail to start up.

This is because the flags `--no-experimental-fetch` and `--dns-result-order=ipv4first` are not valid for node 12.

This PR fixes #593 by only adding these flags for versions higher than 5.13.0 of one-app, which is the version that supports node 16.

This was tested against a module and verified the server starts.