### PR TITLE
chore(release): publish packages

### DIFF
--- a/packages/one-app-bundler/CHANGELOG.md
+++ b/packages/one-app-bundler/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.21.6](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.21.5...@americanexpress/one-app-bundler@6.21.6) (2024-01-02)
+
+
+### Bug Fixes
+
+* **one-app-bundler:** packages don't include package.json in exports ([#594](https://github.com/americanexpress/one-app-cli/issues/594)) ([fcf1567](https://github.com/americanexpress/one-app-cli/commit/fcf1567d0f875aed51858ac86b658e3ad87c5733))
+
+
+
+
+
 ## [6.21.5](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.21.3...@americanexpress/one-app-bundler@6.21.5) (2023-11-13)
 
 

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-bundler",
-  "version": "6.21.5",
+  "version": "6.21.6",
   "description": "A command line interface(CLI) tool for bundling One App and its modules.",
   "main": "index.js",
   "bin": {

--- a/packages/one-app-runner/CHANGELOG.md
+++ b/packages/one-app-runner/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.16.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.16.0...@americanexpress/one-app-runner@6.16.2) (2024-01-02)
+
+
+### Bug Fixes
+
+* disable native fetch in node ([#586](https://github.com/americanexpress/one-app-cli/issues/586)) ([4938125](https://github.com/americanexpress/one-app-cli/commit/49381256250c22e6a43585127d3fc304fe5a8d47))
+* **one-app-runner:** suppress npm update notifications ([#589](https://github.com/americanexpress/one-app-cli/issues/589)) ([e769426](https://github.com/americanexpress/one-app-cli/commit/e76942600ccf3bcf3e723fc79afd7468022bf715))
+* runner failed to start with node 12 images ([#597](https://github.com/americanexpress/one-app-cli/issues/597)) ([0a65c2f](https://github.com/americanexpress/one-app-cli/commit/0a65c2fdf53a8535622fe38450319c628fb76c07))
+
+
+
+
+
 ## [6.16.1](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.16.0...@americanexpress/one-app-runner@6.16.1) (2023-11-17)
 
 

--- a/packages/one-app-runner/package.json
+++ b/packages/one-app-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-runner",
-  "version": "6.16.1",
+  "version": "6.16.2",
   "description": "CLI for running One App locally",
   "license": "Apache-2.0",
   "contributors": [


### PR DESCRIPTION
 - @americanexpress/one-app-bundler@6.21.6
 - @americanexpress/one-app-runner@6.16.2
