### PR TITLE
fix(webpack): include typescript files in purgecss loader

### DIFF
--- a/packages/one-app-bundler/__tests__/webpack/loaders/__snapshots__/common.spec.js.snap
+++ b/packages/one-app-bundler/__tests__/webpack/loaders/__snapshots__/common.spec.js.snap
@@ -97,7 +97,7 @@ Array [
       "fontFace": false,
       "keyframes": false,
       "paths": Array [
-        "/current/dir/src/**/*.{js,jsx}",
+        "/current/dir/src/**/*.{js,jsx,ts,tsx}",
         "foo",
         "bar",
       ],
@@ -126,7 +126,7 @@ Array [
       "fontFace": false,
       "keyframes": false,
       "paths": Array [
-        "/current/dir/src/**/*.{js,jsx}",
+        "/current/dir/src/**/*.{js,jsx,ts,tsx}",
       ],
       "safelist": Object {
         "deep": Array [

--- a/packages/one-app-bundler/webpack/loaders/common.js
+++ b/packages/one-app-bundler/webpack/loaders/common.js
@@ -87,7 +87,7 @@ const purgeCssLoader = () => {
   return [{
     loader: '@americanexpress/purgecss-loader',
     options: {
-      paths: [path.join(packageRoot, 'src/**/*.{js,jsx}'), ...purgecss.paths || []],
+      paths: [path.join(packageRoot, 'src/**/*.{js,jsx,ts,tsx}'), ...purgecss.paths || []],
       extractors: purgecss.extractors || [],
       fontFace: purgecss.fontFace || false,
       keyframes: purgecss.keyframes || false,


### PR DESCRIPTION
## **Description**
Apply the purgecss loader to ts/tsx files as well as js/jsx files.

## **Motivation** 

Fixes #600 where css imports are not being handled in typescript files.

It's a bit surprising that overly restricting purgecss would have this effect but it does seem to be the case.

## **Test** **Conditions**

Packed this and installed it on a repo that was having the bug and the styles were rendered properly.

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
