### PR TITLE
chore(deps): upgrade to babel-preset-amex@4

### DIFF
--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -46,7 +46,7 @@
     "@babel/eslint-parser": "^7.17.0",
     "ajv": "^6.7.0",
     "babel-loader": "^8.0.6",
-    "babel-preset-amex": "^3.2.0",
+    "babel-preset-amex": "^4.0.0",
     "chalk": "^2.4.2",
     "core-js-compat": "^3.4.2",
     "css-loader": "3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,6 +462,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
   integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
+"@babel/helper-plugin-utils@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
+  integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
+
 "@babel/helper-remap-async-to-generator@^7.16.8":
   version "7.16.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz#29ffaade68a367e2ed09c90901986918d25e57e3"
@@ -502,6 +507,13 @@
   integrity sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-skip-transparent-expression-wrappers@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz#007f15240b5751c537c40e77abb4e89eeaaa8847"
+  integrity sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==
+  dependencies:
+    "@babel/types" "^7.22.5"
 
 "@babel/helper-split-export-declaration@^7.16.7":
   version "7.16.7"
@@ -779,7 +791,7 @@
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
 
-"@babel/plugin-proposal-optional-chaining@^7.12.1", "@babel/plugin-proposal-optional-chaining@^7.16.7":
+"@babel/plugin-proposal-optional-chaining@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz#7cd629564724816c0e8a969535551f943c64c39a"
   integrity sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==
@@ -1117,6 +1129,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/helper-replace-supers" "^7.16.7"
+
+"@babel/plugin-transform-optional-chaining@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz#6acf61203bdfc4de9d4e52e64490aeb3e52bd017"
+  integrity sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
 "@babel/plugin-transform-parameters@^7.16.7":
   version "7.16.7"
@@ -4070,16 +4091,16 @@ babel-plugin-transform-react-remove-prop-types@^0.4.24:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
-babel-preset-amex@^3.2.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-amex/-/babel-preset-amex-3.5.1.tgz#098d826d8b18b3ec44ede2f4d1fc41e29f4555f4"
-  integrity sha512-52PvU+c+zvHDb95aKOLHwtM/EnTcd6kGxqkoUhMRBYwwG3VOfPAhBU+DrVaeJSUEI1L68RC++TiX8XXizR1zVg==
+babel-preset-amex@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-amex/-/babel-preset-amex-4.0.3.tgz#6a25928502d34c1a864829bcf38e7ef7f18eb22d"
+  integrity sha512-c9cPgwLkUwhkj+tsXCDPVOE1q4xGoVDXvBAX0qysDW72KbxtHUsFRfd+0QbpNdsJUWFo0eFlthS1QDOHALqyFA==
   dependencies:
     "@babel/core" "^7.12.3"
     "@babel/plugin-proposal-class-properties" "^7.12.1"
     "@babel/plugin-proposal-export-default-from" "^7.12.1"
-    "@babel/plugin-proposal-optional-chaining" "^7.12.1"
     "@babel/plugin-syntax-dynamic-import" "^7.2.0"
+    "@babel/plugin-transform-optional-chaining" "^7.23.4"
     "@babel/preset-env" "^7.12.1"
     "@babel/preset-react" "^7.12.5"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"


### PR DESCRIPTION
## **Description**
Update to the new major version of babel-preset-amex.

## **Motivation** 
babel-preset-amex had a major version bump dropping support for EOL node versions 10/12/14.

(It's not 100% clear to me which node versions the bundler supports, but it's definitely not being tested with older versions.)

Bumping the version here will ensure that future updates get picked up.

## **Test** **Conditions**
Passed unit tests.

## **Types of changes**
#### Check boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [x] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
