### PR TITLE
chore(release): publish packages

### DIFF
--- a/packages/one-app-bundler/CHANGELOG.md
+++ b/packages/one-app-bundler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.21.8](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.21.7...@americanexpress/one-app-bundler@6.21.8) (2024-01-31)
+
+**Note:** Version bump only for package @americanexpress/one-app-bundler
+
+
+
+
+
 ## [6.21.7](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-bundler@6.21.6...@americanexpress/one-app-bundler@6.21.7) (2024-01-29)
 
 

--- a/packages/one-app-bundler/package.json
+++ b/packages/one-app-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-bundler",
-  "version": "6.21.7",
+  "version": "6.21.8",
   "description": "A command line interface(CLI) tool for bundling One App and its modules.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
 - @americanexpress/one-app-bundler@6.21.8

Unfortunately since I tagged https://github.com/americanexpress/one-app-cli/pull/602 as a chore, it is not getting included in the changelog.