### PR TITLE
fix(one-app-server-bundler): serve-module read and write the module map once

### DIFF
--- a/packages/one-app-server-bundler/__tests__/bin/serve-module.spec.js
+++ b/packages/one-app-server-bundler/__tests__/bin/serve-module.spec.js
@@ -23,7 +23,7 @@ const setup = (modulePath) => {
   jest.resetModules();
   jest.clearAllMocks();
   jest.doMock('node:util', () => ({
-    parseArgs: jest.fn(() => ({ positionals: [modulePath] })),
+    parseArgs: jest.fn(() => ({ positionals: modulePath ? [modulePath] : [] })),
   }));
 
   fs = require('node:fs');
@@ -43,6 +43,12 @@ describe('serve-module', () => {
 
   afterAll(() => {
     setPlatform(originalPlatform);
+  });
+
+  it('should throw if no module path is provided', () => {
+    setup();
+    fs._.setFiles({});
+    expect(() => require('../../bin/serve-module')).toThrowErrorMatchingInlineSnapshot('"serve-module(s) expects paths to modules to give to one-app to serve"');
   });
 
   it('should throw if the module doesn\'t have a version', () => {

--- a/packages/one-app-server-bundler/__tests__/bin/serve-module.spec.js
+++ b/packages/one-app-server-bundler/__tests__/bin/serve-module.spec.js
@@ -48,7 +48,7 @@ describe('serve-module', () => {
   it('should throw if no module path is provided', () => {
     setup();
     fs._.setFiles({});
-    expect(() => require('../../bin/serve-module')).toThrowErrorMatchingInlineSnapshot('"serve-module(s) expects paths to modules to give to one-app to serve"');
+    expect(() => require('../../bin/serve-module')).toThrowErrorMatchingInlineSnapshot('"serve-module(s) requires at least one module path for one-app to serve"');
   });
 
   it('should throw if the module doesn\'t have a version', () => {

--- a/packages/one-app-server-bundler/bin/serve-module.js
+++ b/packages/one-app-server-bundler/bin/serve-module.js
@@ -25,7 +25,7 @@ fs.mkdirSync(symModulesPath, { recursive: true });
 const modulePaths = util.parseArgs({ allowPositionals: true }).positionals;
 
 if (modulePaths.length === 0) {
-  throw new Error('serve-module(s) expects paths to modules to give to one-app to serve');
+  throw new Error('serve-module(s) requires at least one module path for one-app to serve');
 }
 
 const moduleMapPath = path.join(publicPath, 'module-map.json');

--- a/packages/one-app-server-bundler/bin/serve-module.js
+++ b/packages/one-app-server-bundler/bin/serve-module.js
@@ -22,7 +22,21 @@ const symModulesPath = path.join(publicPath, 'modules');
 
 fs.mkdirSync(symModulesPath, { recursive: true });
 
-util.parseArgs({ allowPositionals: true }).positionals.forEach((modulePath) => {
+const modulePaths = util.parseArgs({ allowPositionals: true }).positionals;
+
+if (modulePaths.length === 0) {
+  throw new Error('serve-module(s) expects paths to modules to give to one-app to serve');
+}
+
+const moduleMapPath = path.join(publicPath, 'module-map.json');
+let moduleMap;
+try {
+  moduleMap = JSON.parse(fs.readFileSync(moduleMapPath));
+} catch (e) {
+  moduleMap = { key: 'not-used-in-development', modules: {} };
+}
+
+modulePaths.forEach((modulePath) => {
   const pkg = JSON.parse(fs.readFileSync(path.join(modulePath, 'package.json')));
   const absoluteModulePath = modulePath.startsWith('/')
     ? modulePath : path.join(process.cwd(), modulePath);
@@ -58,33 +72,25 @@ util.parseArgs({ allowPositionals: true }).positionals.forEach((modulePath) => {
     fs.symlinkSync(sourceBundlePath, symBundlePath, type);
   }
 
-  const moduleMapPath = path.join(publicPath, 'module-map.json');
-  try {
-    fs.accessSync(moduleMapPath);
-  } catch (e) {
-    fs.writeFileSync(moduleMapPath, JSON.stringify({ key: 'not-used-in-development', modules: {} }, null, 2));
-  } finally {
-    const moduleMap = JSON.parse(fs.readFileSync(moduleMapPath));
-    const generalConfig = {
-      browser: {
-        integrity: browserSri,
-        url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.browser.js`,
-      },
-      node: {
-        integrity: nodeSri,
-        url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.node.js`,
-      },
-    };
+  const generalConfig = {
+    browser: {
+      integrity: browserSri,
+      url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.browser.js`,
+    },
+    node: {
+      integrity: nodeSri,
+      url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.node.js`,
+    },
+  };
 
-    const legacyConfig = legacyBrowserSri ? {
-      legacyBrowser: {
-        integrity: legacyBrowserSri,
-        url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.legacy.browser.js`,
-      },
-    } : {};
+  const legacyConfig = legacyBrowserSri ? {
+    legacyBrowser: {
+      integrity: legacyBrowserSri,
+      url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.legacy.browser.js`,
+    },
+  } : {};
 
-    moduleMap.modules[moduleName] = { ...generalConfig, ...legacyConfig };
-
-    fs.writeFileSync(moduleMapPath, JSON.stringify(moduleMap, null, 2));
-  }
+  moduleMap.modules[moduleName] = { ...generalConfig, ...legacyConfig };
 });
+
+fs.writeFileSync(moduleMapPath, JSON.stringify(moduleMap, null, 2));


### PR DESCRIPTION
## **Description**
Read and write the module map from/to disk O(1) rather than O(n) in serve-module.

## **Motivation** 
Filesystem operations are slower than memory operations, so with #622 it'll be useful to reduce the total filesystem operations from `2*number of modules` to just `2`.

Should help reduce startup time with one-app-runner (albeit not as extreme as #622). 

## **Test** **Conditions**
existing tests pass 🙌 
added a test to verify the thrown exception message when no modules are provided

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
