### PR TITLE
allow to use :latest when specifying image tag

### DIFF
--- a/packages/one-app-runner/__tests__/src/startApp.spec.js
+++ b/packages/one-app-runner/__tests__/src/startApp.spec.js
@@ -412,12 +412,12 @@ Array [
     );
   });
 
-  it('adds node flags when one-app version is @latest', async () => {
+  it('adds node flags when one-app version is :latest', async () => {
     expect.assertions(1);
     const mockSpawn = makeMockSpawn();
     childProcess.spawn.mockImplementation(mockSpawn);
     await startApp({
-      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:@latest', modulesToServe: ['/path/to/module-a'],
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:latest', modulesToServe: ['/path/to/module-a'],
     });
     expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatch(
       '--dns-result-order=ipv4first --no-experimental-fetch'

--- a/packages/one-app-runner/__tests__/src/startApp.spec.js
+++ b/packages/one-app-runner/__tests__/src/startApp.spec.js
@@ -412,6 +412,18 @@ Array [
     );
   });
 
+  it('adds node flags when one-app version is @latest', async () => {
+    expect.assertions(1);
+    const mockSpawn = makeMockSpawn();
+    childProcess.spawn.mockImplementation(mockSpawn);
+    await startApp({
+      moduleMapUrl: 'https://example.com/module-map.json', rootModuleName: 'frank-lloyd-root', appDockerImage: 'one-app:@latest', modulesToServe: ['/path/to/module-a'],
+    });
+    expect(mockSpawn.calls[1].args[mockSpawn.calls[1].args.indexOf('-c') + 1]).toMatch(
+      '--dns-result-order=ipv4first --no-experimental-fetch'
+    );
+  });
+
   it('adds node flags when one-app version is greater than 5.13.0 and is a prerelease', async () => {
     expect.assertions(1);
     const mockSpawn = makeMockSpawn();

--- a/packages/one-app-runner/src/startApp.js
+++ b/packages/one-app-runner/src/startApp.js
@@ -136,7 +136,7 @@ const generateDebug = (port, useDebug) => (useDebug ? `--inspect=0.0.0.0:${port}
 // So we have to remove those flags if the one-app version is less than 5.13.0
 // 5.13.0 is when node 16 was introduced.
 const generateNodeFlags = (appVersion) => {
-  if (appVersion === '@latest' ? true : semver.intersects(appVersion, '^5.13.0', { includePrerelease: true })) {
+  if (appVersion === 'latest' ? true : semver.intersects(appVersion, '^5.13.0', { includePrerelease: true })) {
     return '--dns-result-order=ipv4first --no-experimental-fetch';
   }
   return '';

--- a/packages/one-app-runner/src/startApp.js
+++ b/packages/one-app-runner/src/startApp.js
@@ -136,7 +136,7 @@ const generateDebug = (port, useDebug) => (useDebug ? `--inspect=0.0.0.0:${port}
 // So we have to remove those flags if the one-app version is less than 5.13.0
 // 5.13.0 is when node 16 was introduced.
 const generateNodeFlags = (appVersion) => {
-  if (semver.intersects(appVersion, '^5.13.0', { includePrerelease: true })) {
+  if (appVersion === '@latest' ? true : semver.intersects(appVersion, '^5.13.0', { includePrerelease: true })) {
     return '--dns-result-order=ipv4first --no-experimental-fetch';
   }
   return '';


### PR DESCRIPTION
fixing a bug where it wasn't possible to use :latest tag when specifying the image



## **Types of changes**
#### Check boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
