### PR TITLE
fix(one-app-runner): include legacy bundle on serve-module even if it does not exist

### DIFF
--- a/packages/one-app-server-bundler/__tests__/bin/__snapshots__/serve-module.spec.js.snap
+++ b/packages/one-app-server-bundler/__tests__/bin/__snapshots__/serve-module.spec.js.snap
@@ -36,7 +36,7 @@ exports[`serve-module adds to the existing module map 1`] = `
 }"
 `;
 
-exports[`serve-module adds to the existing module map without legacy when legacy bundle does not exist 1`] = `
+exports[`serve-module adds to the existing module map with a warning in place of the legacy browser SRI when legacy bundle does not exist 1`] = `
 "{
   \\"key\\": \\"--- omitted for development ---\\",
   \\"modules\\": {
@@ -58,6 +58,10 @@ exports[`serve-module adds to the existing module map without legacy when legacy
       \\"node\\": {
         \\"integrity\\": \\"123\\",
         \\"url\\": \\"[one-app-dev-cdn-url]/static/modules/my-module-name/1.0.0/my-module-name.node.js\\"
+      },
+      \\"legacyBrowser\\": {
+        \\"integrity\\": \\"[No legacy bundle generated for my-module-name. This will 404.]\\",
+        \\"url\\": \\"[one-app-dev-cdn-url]/static/modules/my-module-name/1.0.0/my-module-name.legacy.browser.js\\"
       }
     }
   }

--- a/packages/one-app-server-bundler/__tests__/bin/serve-module.spec.js
+++ b/packages/one-app-server-bundler/__tests__/bin/serve-module.spec.js
@@ -152,7 +152,7 @@ describe('serve-module', () => {
     expect(fs._.getFiles()['/mocked/static/module-map.json']).toMatchSnapshot();
   });
 
-  it('adds to the existing module map without legacy when legacy bundle does not exist', () => {
+  it('adds to the existing module map with a warning in place of the legacy browser SRI when legacy bundle does not exist', () => {
     process.env.NODE_ENV = 'development';
     fs._.setFiles({
       '../my-module-name/package.json': JSON.stringify({ name: 'my-module-name', version: '1.0.0' }),

--- a/packages/one-app-server-bundler/bin/serve-module.js
+++ b/packages/one-app-server-bundler/bin/serve-module.js
@@ -65,7 +65,7 @@ util.parseArgs({ allowPositionals: true }).positionals.forEach((modulePath) => {
     fs.writeFileSync(moduleMapPath, JSON.stringify({ key: 'not-used-in-development', modules: {} }, null, 2));
   } finally {
     const moduleMap = JSON.parse(fs.readFileSync(moduleMapPath));
-    const generalConfig = {
+    moduleMap.modules[moduleName] = {
       browser: {
         integrity: browserSri,
         url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.browser.js`,
@@ -74,16 +74,11 @@ util.parseArgs({ allowPositionals: true }).positionals.forEach((modulePath) => {
         integrity: nodeSri,
         url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.node.js`,
       },
-    };
-
-    const legacyConfig = legacyBrowserSri ? {
       legacyBrowser: {
-        integrity: legacyBrowserSri,
+        integrity: legacyBrowserSri || `[No legacy bundle generated for ${moduleName}. This will 404.]`,
         url: `[one-app-dev-cdn-url]/static/modules/${moduleName}/${version}/${moduleName}.legacy.browser.js`,
       },
-    } : {};
-
-    moduleMap.modules[moduleName] = { ...generalConfig, ...legacyConfig };
+    };
 
     fs.writeFileSync(moduleMapPath, JSON.stringify(moduleMap, null, 2));
   }


### PR DESCRIPTION
## **Description**

Always include a legacy bundle entry in module map

## **Motivation** 

Serving modules without legacy bundles caused dev cdn to choke


## **Test** **Conditions**

- Updated unit
- Manually validated running serve-module

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
