### PR TITLE
chore(release): publish packages

### DIFF
--- a/packages/one-app-runner/CHANGELOG.md
+++ b/packages/one-app-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.17.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.17.1...@americanexpress/one-app-runner@6.17.2) (2024-03-26)
+
+**Note:** Version bump only for package @americanexpress/one-app-runner
+
+
+
+
+
 ## [6.17.1](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.17.0...@americanexpress/one-app-runner@6.17.1) (2024-03-20)
 
 

--- a/packages/one-app-runner/CHANGELOG.md
+++ b/packages/one-app-runner/CHANGELOG.md
@@ -5,7 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [6.17.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-runner@6.17.1...@americanexpress/one-app-runner@6.17.2) (2024-03-26)
 
-**Note:** Version bump only for package @americanexpress/one-app-runner
+### Bug Fixes
+
+* **one-app-runner:** allow :latest and versions >=6.6.0 when specifying image tag ([#628]((https://github.com/americanexpress/one-app-cli/issues/622))) ([82d33e0](https://github.com/americanexpress/one-app-cli/commit/82d33e0a6ac704a493c6005e778b4dfa0902c1ec))
 
 
 

--- a/packages/one-app-runner/package.json
+++ b/packages/one-app-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-runner",
-  "version": "6.17.1",
+  "version": "6.17.2",
   "description": "CLI for running One App locally",
   "license": "Apache-2.0",
   "contributors": [

--- a/packages/one-app-server-bundler/CHANGELOG.md
+++ b/packages/one-app-server-bundler/CHANGELOG.md
@@ -8,7 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* **one-app-runner:** include legacy bundle on serve-module even if it does not exist ([#629](https://github.com/americanexpress/one-app-cli/issues/629)) ([f48ef4f](https://github.com/americanexpress/one-app-cli/commit/f48ef4f3f0516e8fb3dc9e4246507b10feb47ca5))
+* **one-app-server-bundler:** include legacy bundle on serve-module even if it does not exist ([#629](https://github.com/americanexpress/one-app-cli/issues/629)) ([f48ef4f](https://github.com/americanexpress/one-app-cli/commit/f48ef4f3f0516e8fb3dc9e4246507b10feb47ca5))
 
 
 

--- a/packages/one-app-server-bundler/CHANGELOG.md
+++ b/packages/one-app-server-bundler/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.3](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-server-bundler@1.0.2...@americanexpress/one-app-server-bundler@1.0.3) (2024-03-26)
+
+
+### Bug Fixes
+
+* **one-app-runner:** include legacy bundle on serve-module even if it does not exist ([#629](https://github.com/americanexpress/one-app-cli/issues/629)) ([f48ef4f](https://github.com/americanexpress/one-app-cli/commit/f48ef4f3f0516e8fb3dc9e4246507b10feb47ca5))
+
+
+
+
+
 ## [1.0.2](https://github.com/americanexpress/one-app-cli/compare/@americanexpress/one-app-server-bundler@1.0.1...@americanexpress/one-app-server-bundler@1.0.2) (2024-03-15)
 
 

--- a/packages/one-app-server-bundler/package.json
+++ b/packages/one-app-server-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-app-server-bundler",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A command line interface(CLI) tool for bundling the One App server.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
 - @americanexpress/one-app-runner@6.17.2
 - @americanexpress/one-app-server-bundler@1.0.3

Release #628 & #629 