### PR TITLE
fix: transpile cjs files

### DIFF
--- a/packages/one-app-server-bundler/__tests__/webpack/app/__snapshots__/webpack.client.spec.js.snap
+++ b/packages/one-app-server-bundler/__tests__/webpack/app/__snapshots__/webpack.client.spec.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports['webpack/app always transpiles node_modules when env is production 1'] = `
+exports[`webpack/app always transpiles node_modules when env is production 1`] = `
 Object {
   "exclude": /\\^\\\\/node_modules\\\\/core-js/,
   "include": Array [
     "/src",
     "/node_modules",
   ],
-  "test": /\\\\\\.jsx\\?\\$/,
+  "test": /\\\\\\.c\\?jsx\\?\\$/,
   "use": Array [
     Object {
       "loader": "babel-loader",
@@ -21,13 +21,13 @@ Object {
 }
 `;
 
-exports['webpack/app does not transpile node_modules when DANGEROUSLY_DISABLE_DEPENDENCY_TRANSPILATION true 1'] = `
+exports[`webpack/app does not transpile node_modules when DANGEROUSLY_DISABLE_DEPENDENCY_TRANSPILATION true 1`] = `
 Object {
   "exclude": /\\^\\\\/node_modules\\\\/core-js/,
   "include": Array [
     "/src",
   ],
-  "test": /\\\\\\.jsx\\?\\$/,
+  "test": /\\\\\\.c\\?jsx\\?\\$/,
   "use": Array [
     Object {
       "loader": "babel-loader",
@@ -41,14 +41,14 @@ Object {
 }
 `;
 
-exports['webpack/app transpiles node_modules when DANGEROUSLY_DISABLE_DEPENDENCY_TRANSPILATION false 1'] = `
+exports[`webpack/app transpiles node_modules when DANGEROUSLY_DISABLE_DEPENDENCY_TRANSPILATION false 1`] = `
 Object {
   "exclude": /\\^\\\\/node_modules\\\\/core-js/,
   "include": Array [
     "/src",
     "/node_modules",
   ],
-  "test": /\\\\\\.jsx\\?\\$/,
+  "test": /\\\\\\.c\\?jsx\\?\\$/,
   "use": Array [
     Object {
       "loader": "babel-loader",

--- a/packages/one-app-server-bundler/webpack/app/webpack.client.js
+++ b/packages/one-app-server-bundler/webpack/app/webpack.client.js
@@ -87,7 +87,7 @@ module.exports = (babelEnv) => merge(
     module: {
       rules: [
         {
-          test: /\.jsx?$/,
+          test: /\.c?jsx?$/,
           include: pathsToTranspile,
           exclude: new RegExp(`^${path.resolve(packageRoot, 'node_modules', 'core-js')}`),
           use: [babelLoader(babelEnv)],


### PR DESCRIPTION
#### Provide a general summary of your changes in the Title above.

## **Description**
#### _Describe your changes in detail_
With the upgrade of `enhanced-resolve` from #619, we started to resolve CJS files.
We didn't transpile these files first, so newer syntax was throwing an error, example `zx ?? y`. 

This became obvious with the update to `react-redux` in the `next` branch of `one-app`, since the latest version of `react-redux` ships more modern builds.

## **Motivation** 

Allow transpiling of cjs

## **Test** **Conditions**

Packed this change up and installed it in the failing branch in one-app, and confirmed it fixes the issue.

Also verified the regex still matches what we'd expect
![image](https://github.com/americanexpress/one-app-cli/assets/7441013/d3b6aa1d-41d4-4c7a-83c9-db8ae7a04a50)


## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
