### PR TITLE
fix(load-styles): export css module classes as-is

### DIFF
--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/styles-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/styles-loader.spec.js
@@ -149,11 +149,11 @@ const css = \`                ._root_w8zvp_1 {
     document.head.appendChild(el);
   }
 })();
-export const root = '_root_w8zvp_1';
-export const second = '_second_w8zvp_9';
-export default { root, second };
-export { css, digest };"
-`);
+module.exports = { 'root': '_root_w8zvp_1', 'second': '_second_w8zvp_9' }
+module['css'] = css;
+module['digest'] = digest;"
+`
+          );
         });
 
         it('should transform inputs to named outputs for purged css, browser', async () => {
@@ -225,11 +225,11 @@ const css = \`                ._root_w8zvp_1 {
     document.head.appendChild(el);
   }
 })();
-export const root = '_root_w8zvp_1';
-export const second = '_second_w8zvp_9';
-export default { root, second };
-export { css, digest };"
-`);
+module.exports = { 'root': '_root_w8zvp_1', 'second': '_second_w8zvp_9' }
+module['css'] = css;
+module['digest'] = digest;"
+`
+          );
         });
 
         it('should transform inputs to outputs for scss, in the browser', async () => {
@@ -274,9 +274,9 @@ body > p {
     document.head.appendChild(el);
   }
 })();
-
-export default {  };
-export { css, digest };"
+module.exports = {  }
+module['css'] = css;
+module['digest'] = digest;"
 `);
         });
 
@@ -319,9 +319,9 @@ body > p {
     document.head.appendChild(el);
   }
 })();
-
-export default {  };
-export { css, digest };"
+module.exports = {  }
+module['css'] = css;
+module['digest'] = digest;"
 `);
         });
 
@@ -351,19 +351,19 @@ export { css, digest };"
 
           expect(loader).toEqual('js');
           expect(contents).toMatchInlineSnapshot(`
-  "const digest = '11e1fda0219a10c2de0ad6b28c1c6519985965cbef3f5b8f8f119d16f1bafff3';
-  const css = \`body {
-    background: white;
-  }
-  
-  body > p {
-    font-color: black;
-  }\`;
-  
-  
-  export default {  };
-  export { css, digest };"
-  `);
+"const digest = '11e1fda0219a10c2de0ad6b28c1c6519985965cbef3f5b8f8f119d16f1bafff3';
+const css = \`body {
+  background: white;
+}
+
+body > p {
+  font-color: black;
+}\`;
+
+module.exports = {  }
+module['css'] = css;
+module['digest'] = digest;"
+`);
         });
 
         it('should transform inputs to outputs for css, in the server', async () => {
@@ -398,9 +398,9 @@ body > p {
   font-color: black;
 }\`;
 
-
-export default {  };
-export { css, digest };"
+module.exports = {  }
+module['css'] = css;
+module['digest'] = digest;"
 `);
         });
 
@@ -448,9 +448,9 @@ const css = \`._test-class_1o1cd_1 {
     document.head.appendChild(el);
   }
 })();
-
-export default { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' };
-export { css, digest };"
+module.exports = { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' }
+module['css'] = css;
+module['digest'] = digest;"
 `
             );
           });
@@ -489,9 +489,9 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-
-export default { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' };
-export { css, digest };"
+module.exports = { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' }
+module['css'] = css;
+module['digest'] = digest;"
 `
             );
           });
@@ -531,9 +531,9 @@ const css = \`._test-class_1o1cd_1 {
     document.head.appendChild(el);
   }
 })();
-
-export default { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' };
-export { css, digest };"
+module.exports = { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' }
+module['css'] = css;
+module['digest'] = digest;"
 `
             );
           });
@@ -572,9 +572,9 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-
-export default { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' };
-export { css, digest };"
+module.exports = { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' }
+module['css'] = css;
+module['digest'] = digest;"
 `
             );
           });
@@ -614,9 +614,9 @@ const css = \`.test-class {
     document.head.appendChild(el);
   }
 })();
-
-export default { 'test-class': 'test-class', 'nested-class': 'nested-class' };
-export { css, digest };"
+module.exports = { 'test-class': 'test-class', 'nested-class': 'nested-class' }
+module['css'] = css;
+module['digest'] = digest;"
 `
             );
           });
@@ -655,9 +655,9 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-
-export default { 'test-class': 'test-class', 'nested-class': 'nested-class' };
-export { css, digest };"
+module.exports = { 'test-class': 'test-class', 'nested-class': 'nested-class' }
+module['css'] = css;
+module['digest'] = digest;"
 `
             );
           });
@@ -696,9 +696,9 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-export const testClass = '_testClass_nd9j1_2';
-export default { testClass };
-export { css, digest };"
+module.exports = { 'testClass': '_testClass_nd9j1_2' }
+module['css'] = css;
+module['digest'] = digest;"
 `);
           });
 
@@ -734,9 +734,9 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-
-export default { 'test-class': '_test-class_jogu8_2' };
-export { css, digest };"
+module.exports = { 'test-class': '_test-class_jogu8_2' }
+module['css'] = css;
+module['digest'] = digest;"
 `);
           });
 
@@ -772,9 +772,9 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-export const TestClass = '_TestClass_ndabk_2';
-export default { TestClass };
-export { css, digest };"
+module.exports = { 'TestClass': '_TestClass_ndabk_2' }
+module['css'] = css;
+module['digest'] = digest;"
 `);
           });
 
@@ -822,11 +822,11 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-export const testClass = '_testClass_1mj1y_2';
-export const TestClass = '_TestClass_1mj1y_8';
-export default { testClass, TestClass, 'test-class': '_test-class_1mj1y_5' };
-export { css, digest };"
-`);
+module.exports = { 'testClass': '_testClass_1mj1y_2', 'test-class': '_test-class_1mj1y_5', 'TestClass': '_TestClass_1mj1y_8' }
+module['css'] = css;
+module['digest'] = digest;"
+`
+            );
           });
         });
 
@@ -896,12 +896,11 @@ const css = \`            ._root_18xtd_1 {
     document.head.appendChild(el);
   }
 })();
-export const root = '_root_18xtd_1';
-export const somethingElse = '_somethingElse_18xtd_5';
-export const second = '_second_18xtd_9';
-export default { root, somethingElse, second };
-export { css, digest };"
-`);
+module.exports = { 'root': '_root_18xtd_1', 'somethingElse': '_somethingElse_18xtd_5', 'second': '_second_18xtd_9' }
+module['css'] = css;
+module['digest'] = digest;"
+`
+            );
           });
 
           it('should purge css if disabled === false', async () => {
@@ -938,11 +937,11 @@ const css = \`            ._root_18xtd_1 {
     document.head.appendChild(el);
   }
 })();
-export const root = '_root_18xtd_1';
-export const second = '_second_18xtd_9';
-export default { root, second };
-export { css, digest };"
-`);
+module.exports = { 'root': '_root_18xtd_1', 'second': '_second_18xtd_9' }
+module['css'] = css;
+module['digest'] = digest;"
+`
+            );
           });
 
           it('should purge css if enabled === true', async () => {
@@ -979,11 +978,11 @@ const css = \`            ._root_18xtd_1 {
     document.head.appendChild(el);
   }
 })();
-export const root = '_root_18xtd_1';
-export const second = '_second_18xtd_9';
-export default { root, second };
-export { css, digest };"
-`);
+module.exports = { 'root': '_root_18xtd_1', 'second': '_second_18xtd_9' }
+module['css'] = css;
+module['digest'] = digest;"
+`
+            );
           });
         });
       });
@@ -1060,11 +1059,11 @@ const css = \`              ._root_1vf0l_1 {
     document.head.appendChild(el);
   }
 })();
-export const root = '_root_1vf0l_1';
-export const second = '_second_1vf0l_9';
-export default { root, second };
-export { css, digest };"
-`);
+module.exports = { 'root': '_root_1vf0l_1', 'second': '_second_1vf0l_9' }
+module['css'] = css;
+module['digest'] = digest;"
+`
+          );
         });
 
         it('should transform inputs to named outputs for purged css, browser', async () => {
@@ -1136,11 +1135,11 @@ const css = \`              ._root_1vf0l_1 {
     document.head.appendChild(el);
   }
 })();
-export const root = '_root_1vf0l_1';
-export const second = '_second_1vf0l_9';
-export default { root, second };
-export { css, digest };"
-`);
+module.exports = { 'root': '_root_1vf0l_1', 'second': '_second_1vf0l_9' }
+module['css'] = css;
+module['digest'] = digest;"
+`
+          );
         });
 
         it('should transform inputs to outputs for scss, in the browser', async () => {
@@ -1185,9 +1184,9 @@ body > p {
     document.head.appendChild(el);
   }
 })();
-
-export default {  };
-export { css, digest };"
+module.exports = {  }
+module['css'] = css;
+module['digest'] = digest;"
 `);
         });
 
@@ -1230,9 +1229,9 @@ body > p {
     document.head.appendChild(el);
   }
 })();
-
-export default {  };
-export { css, digest };"
+module.exports = {  }
+module['css'] = css;
+module['digest'] = digest;"
 `);
         });
       });

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/styles-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/styles-loader.spec.js
@@ -149,7 +149,7 @@ const css = \`                ._root_w8zvp_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'root': '_root_w8zvp_1', 'second': '_second_w8zvp_9' }
+module.exports = { 'root': '_root_w8zvp_1', 'second': '_second_w8zvp_9' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -225,7 +225,7 @@ const css = \`                ._root_w8zvp_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'root': '_root_w8zvp_1', 'second': '_second_w8zvp_9' }
+module.exports = { 'root': '_root_w8zvp_1', 'second': '_second_w8zvp_9' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -274,7 +274,7 @@ body > p {
     document.head.appendChild(el);
   }
 })();
-module.exports = {  }
+module.exports = {  };
 module['css'] = css;
 module['digest'] = digest;"
 `);
@@ -319,7 +319,7 @@ body > p {
     document.head.appendChild(el);
   }
 })();
-module.exports = {  }
+module.exports = {  };
 module['css'] = css;
 module['digest'] = digest;"
 `);
@@ -360,7 +360,7 @@ body > p {
   font-color: black;
 }\`;
 
-module.exports = {  }
+module.exports = {  };
 module['css'] = css;
 module['digest'] = digest;"
 `);
@@ -398,7 +398,7 @@ body > p {
   font-color: black;
 }\`;
 
-module.exports = {  }
+module.exports = {  };
 module['css'] = css;
 module['digest'] = digest;"
 `);
@@ -448,7 +448,7 @@ const css = \`._test-class_1o1cd_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' }
+module.exports = { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -489,7 +489,7 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' }
+module.exports = { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -531,7 +531,7 @@ const css = \`._test-class_1o1cd_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' }
+module.exports = { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -572,7 +572,7 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' }
+module.exports = { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -614,7 +614,7 @@ const css = \`.test-class {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'test-class': 'test-class', 'nested-class': 'nested-class' }
+module.exports = { 'test-class': 'test-class', 'nested-class': 'nested-class' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -655,7 +655,7 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'test-class': 'test-class', 'nested-class': 'nested-class' }
+module.exports = { 'test-class': 'test-class', 'nested-class': 'nested-class' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -696,7 +696,7 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'testClass': '_testClass_nd9j1_2' }
+module.exports = { 'testClass': '_testClass_nd9j1_2' };
 module['css'] = css;
 module['digest'] = digest;"
 `);
@@ -734,7 +734,7 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'test-class': '_test-class_jogu8_2' }
+module.exports = { 'test-class': '_test-class_jogu8_2' };
 module['css'] = css;
 module['digest'] = digest;"
 `);
@@ -772,7 +772,7 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'TestClass': '_TestClass_ndabk_2' }
+module.exports = { 'TestClass': '_TestClass_ndabk_2' };
 module['css'] = css;
 module['digest'] = digest;"
 `);
@@ -822,7 +822,7 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'testClass': '_testClass_1mj1y_2', 'test-class': '_test-class_1mj1y_5', 'TestClass': '_TestClass_1mj1y_8' }
+module.exports = { 'testClass': '_testClass_1mj1y_2', 'test-class': '_test-class_1mj1y_5', 'TestClass': '_TestClass_1mj1y_8' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -896,7 +896,7 @@ const css = \`            ._root_18xtd_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'root': '_root_18xtd_1', 'somethingElse': '_somethingElse_18xtd_5', 'second': '_second_18xtd_9' }
+module.exports = { 'root': '_root_18xtd_1', 'somethingElse': '_somethingElse_18xtd_5', 'second': '_second_18xtd_9' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -937,7 +937,7 @@ const css = \`            ._root_18xtd_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'root': '_root_18xtd_1', 'second': '_second_18xtd_9' }
+module.exports = { 'root': '_root_18xtd_1', 'second': '_second_18xtd_9' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -978,7 +978,7 @@ const css = \`            ._root_18xtd_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'root': '_root_18xtd_1', 'second': '_second_18xtd_9' }
+module.exports = { 'root': '_root_18xtd_1', 'second': '_second_18xtd_9' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -1059,7 +1059,7 @@ const css = \`              ._root_1vf0l_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'root': '_root_1vf0l_1', 'second': '_second_1vf0l_9' }
+module.exports = { 'root': '_root_1vf0l_1', 'second': '_second_1vf0l_9' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -1135,7 +1135,7 @@ const css = \`              ._root_1vf0l_1 {
     document.head.appendChild(el);
   }
 })();
-module.exports = { 'root': '_root_1vf0l_1', 'second': '_second_1vf0l_9' }
+module.exports = { 'root': '_root_1vf0l_1', 'second': '_second_1vf0l_9' };
 module['css'] = css;
 module['digest'] = digest;"
 `
@@ -1184,7 +1184,7 @@ body > p {
     document.head.appendChild(el);
   }
 })();
-module.exports = {  }
+module.exports = {  };
 module['css'] = css;
 module['digest'] = digest;"
 `);
@@ -1229,7 +1229,7 @@ body > p {
     document.head.appendChild(el);
   }
 })();
-module.exports = {  }
+module.exports = {  };
 module['css'] = css;
 module['digest'] = digest;"
 `);

--- a/packages/one-app-dev-bundler/__tests__/esbuild/plugins/styles-loader.spec.js
+++ b/packages/one-app-dev-bundler/__tests__/esbuild/plugins/styles-loader.spec.js
@@ -448,11 +448,11 @@ const css = \`._test-class_1o1cd_1 {
     document.head.appendChild(el);
   }
 })();
-export const testClass = '_test-class_1o1cd_1';
-export const nestedClass = '_nested-class_1o1cd_5';
-export default { testClass, nestedClass };
+
+export default { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' };
 export { css, digest };"
-`);
+`
+            );
           });
 
           it('should hash the css classes for .css files not in node_modules', async () => {
@@ -489,11 +489,11 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-export const testClass = '_test-class_ykkej_2';
-export const nestedClass = '_nested-class_ykkej_5';
-export default { testClass, nestedClass };
+
+export default { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' };
 export { css, digest };"
-`);
+`
+            );
           });
 
           it('should hash the css classes for .module.scss files in node_modules', async () => {
@@ -531,11 +531,11 @@ const css = \`._test-class_1o1cd_1 {
     document.head.appendChild(el);
   }
 })();
-export const testClass = '_test-class_1o1cd_1';
-export const nestedClass = '_nested-class_1o1cd_5';
-export default { testClass, nestedClass };
+
+export default { 'test-class': '_test-class_1o1cd_1', 'nested-class': '_nested-class_1o1cd_5' };
 export { css, digest };"
-`);
+`
+            );
           });
 
           it('should hash the css classes for .module.css files in node_modules', async () => {
@@ -572,11 +572,11 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-export const testClass = '_test-class_ykkej_2';
-export const nestedClass = '_nested-class_ykkej_5';
-export default { testClass, nestedClass };
+
+export default { 'test-class': '_test-class_ykkej_2', 'nested-class': '_nested-class_ykkej_5' };
 export { css, digest };"
-`);
+`
+            );
           });
 
           it('should not hash the css classes for .scss files in node_modules', async () => {
@@ -614,11 +614,11 @@ const css = \`.test-class {
     document.head.appendChild(el);
   }
 })();
-export const testClass = 'test-class';
-export const nestedClass = 'nested-class';
-export default { testClass, nestedClass };
+
+export default { 'test-class': 'test-class', 'nested-class': 'nested-class' };
 export { css, digest };"
-`);
+`
+            );
           });
 
           it('should not hash the css classes for .css files in node_modules', async () => {
@@ -655,9 +655,176 @@ const css = \`
     document.head.appendChild(el);
   }
 })();
-export const testClass = 'test-class';
-export const nestedClass = 'nested-class';
-export default { testClass, nestedClass };
+
+export default { 'test-class': 'test-class', 'nested-class': 'nested-class' };
+export { css, digest };"
+`
+            );
+          });
+        });
+
+        describe('css module class name mapping', () => {
+          it('should map camelCase class names to camelCase export', async () => {
+            expect.assertions(1);
+            const mockFileContentCamelCase = `
+.testClass {
+  background: white;
+}`;
+
+            const mockFileName = 'index.module.css';
+            const plugin = stylesLoader({}, {
+              bundleType: BUNDLE_TYPES.BROWSER,
+            });
+            const onLoadHook = runSetupAndGetLifeHooks(plugin).onLoad[0].hookFunction;
+
+            const { contents } = await runOnLoadHook(
+              onLoadHook,
+              { mockFileName, mockFileContent: mockFileContentCamelCase }
+            );
+
+            expect(contents).toMatchInlineSnapshot(`
+"const digest = '226b4f2da43972a4fc06e45959f141575ff54d5112c560f4e9317565d5f7f7e3';
+const css = \`
+._testClass_nd9j1_2 {
+  background: white;
+}\`;
+(function() {
+  if ( global.BROWSER && !document.getElementById(digest)) {
+    var el = document.createElement('style');
+    el.id = digest;
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+})();
+export const testClass = '_testClass_nd9j1_2';
+export default { testClass };
+export { css, digest };"
+`);
+          });
+
+          it('should map kebab-case class names to kebab-case export', async () => {
+            expect.assertions(1);
+            const mockFileContentKebabCase = `
+.test-class {
+  background: white;
+}`;
+
+            const mockFileName = 'index.module.css';
+            const plugin = stylesLoader({}, {
+              bundleType: BUNDLE_TYPES.BROWSER,
+            });
+            const onLoadHook = runSetupAndGetLifeHooks(plugin).onLoad[0].hookFunction;
+
+            const { contents } = await runOnLoadHook(
+              onLoadHook,
+              { mockFileName, mockFileContent: mockFileContentKebabCase }
+            );
+
+            expect(contents).toMatchInlineSnapshot(`
+"const digest = '4e6b6b5fb2aba1e71d4f619563aa5dd3196dc39177fec2591ba5985b7fce1c2a';
+const css = \`
+._test-class_jogu8_2 {
+  background: white;
+}\`;
+(function() {
+  if ( global.BROWSER && !document.getElementById(digest)) {
+    var el = document.createElement('style');
+    el.id = digest;
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+})();
+
+export default { 'test-class': '_test-class_jogu8_2' };
+export { css, digest };"
+`);
+          });
+
+          it('should map PascalCase class names to PascalCase export', async () => {
+            expect.assertions(1);
+            const mockFileContentPascalCase = `
+.TestClass {
+  background: white;
+}`;
+
+            const mockFileName = 'index.module.css';
+            const plugin = stylesLoader({}, {
+              bundleType: BUNDLE_TYPES.BROWSER,
+            });
+            const onLoadHook = runSetupAndGetLifeHooks(plugin).onLoad[0].hookFunction;
+
+            const { contents } = await runOnLoadHook(
+              onLoadHook,
+              { mockFileName, mockFileContent: mockFileContentPascalCase }
+            );
+
+            expect(contents).toMatchInlineSnapshot(`
+"const digest = '86d0ab75f61f32582cec3b0195d0ecfbde103f660afbc7426663ada518f1f0a5';
+const css = \`
+._TestClass_ndabk_2 {
+  background: white;
+}\`;
+(function() {
+  if ( global.BROWSER && !document.getElementById(digest)) {
+    var el = document.createElement('style');
+    el.id = digest;
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+})();
+export const TestClass = '_TestClass_ndabk_2';
+export default { TestClass };
+export { css, digest };"
+`);
+          });
+
+          it('should map a combination of class names to the correct export', async () => {
+            expect.assertions(1);
+            const mockFileContent = `
+.testClass {
+  background: white;
+}
+.test-class {
+  font-color: black;
+}
+.TestClass {
+  font-size: 16px;
+}`;
+
+            const mockFileName = 'index.module.css';
+            const plugin = stylesLoader({}, {
+              bundleType: BUNDLE_TYPES.BROWSER,
+            });
+            const onLoadHook = runSetupAndGetLifeHooks(plugin).onLoad[0].hookFunction;
+
+            const { contents } = await runOnLoadHook(
+              onLoadHook,
+              { mockFileName, mockFileContent }
+            );
+
+            expect(contents).toMatchInlineSnapshot(`
+"const digest = 'ed48420423f1f7e20e2928760486f1e4601840fc4eede99b965397aa5f739bb8';
+const css = \`
+._testClass_1mj1y_2 {
+  background: white;
+}
+._test-class_1mj1y_5 {
+  font-color: black;
+}
+._TestClass_1mj1y_8 {
+  font-size: 16px;
+}\`;
+(function() {
+  if ( global.BROWSER && !document.getElementById(digest)) {
+    var el = document.createElement('style');
+    el.id = digest;
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+})();
+export const testClass = '_testClass_1mj1y_2';
+export const TestClass = '_TestClass_1mj1y_8';
+export default { testClass, TestClass, 'test-class': '_test-class_1mj1y_5' };
 export { css, digest };"
 `);
           });

--- a/packages/one-app-dev-bundler/esbuild/utils/load-styles.js
+++ b/packages/one-app-dev-bundler/esbuild/utils/load-styles.js
@@ -36,7 +36,7 @@ const getGenerateScopedNameOption = (path) => {
 const generateCssModuleExports = (cssModulesJSON) => {
   const entries = Object.entries(cssModulesJSON);
 
-  return `module.exports = { ${entries.map(([exportName, className]) => `'${exportName}': '${className}'`).join(', ')} }`;
+  return `module.exports = { ${entries.map(([exportName, className]) => `'${exportName}': '${className}'`).join(', ')} };`;
 };
 
 const generateJsContent = ({


### PR DESCRIPTION
## **Description**

> Note: this reverts an unintentional breaking change introduced with v7 of the one app bundler.

Updates `load-styles` to map css module class names using an "as-is" strategy, rather than a "camelCaseOnly" strategy in order to match the behavior of the webpack-based styles loader in `@americanexpress/one-app-bundler@6`. To be fully backwards-compatible with the webpack implementation, the exports needed to be changed to cjs-style exports.

## **Motivation** 

In switching over to `load-styles` provided by the dev bundler with the release of `@americanexpress/one-app-bundler@7`, an unintentional breaking change was introduced to the way that css module classes were mapped and exported when loading the styles. The webpack-based styles loader exported classes "as-is", while the esbuild-based styles loader exported classes in "camelCaseOnly". Additionally, the webpack delivered exports using cjs-style exports, rather than esm-style exports.

## **Test** **Conditions**

Added unit tests for the most common ways people would define classes in css modules. Additionally, validated the changes in a test module.

**Behavior in Production Bundler v6**

![Screenshot 2024-04-18 at 10 05 29 AM](https://github.com/americanexpress/one-app-cli/assets/44091329/1b2a75e4-2d29-46dc-babe-d0423caa1443)

**Existing Behavior in Production (and dev) Bundler v7**

![Screenshot 2024-04-22 at 5 00 07 PM](https://github.com/americanexpress/one-app-cli/assets/44091329/381ca094-b29e-4eba-a306-7c5a1653f651)

**New Behavior With This Change**

![Screenshot 2024-04-23 at 9 58 42 AM](https://github.com/americanexpress/one-app-cli/assets/44091329/8662f69e-1da1-4ec0-8f30-c03dcf6be2d8)

![Screenshot 2024-04-23 at 10 05 50 AM](https://github.com/americanexpress/one-app-cli/assets/44091329/27e59fd1-4d73-47e8-8318-b759886136f6)

## **Types of changes**
#### Check boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update


## **Checklist**
#### Check boxes that apply:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.
